### PR TITLE
Load transaction objects into validate script

### DIFF
--- a/objects/transactions/WarrantIssuance.schema.json
+++ b/objects/transactions/WarrantIssuance.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "Objects.Transactions.Warrant.schema.json",
+  "$id": "Objects.Transactions.WarrantIssuance.schema.json",
   "title": "Object - Warrant Issuance Transaction",
   "description": "Object describing warrant issuance transaction by the issuer and held by a stakeholder",
   "type": "object",
@@ -51,15 +51,15 @@
     },
     "quantity": {
       "description": "Quantity of shares the warrant is exercisable for",
-      "type": "Types.Numeric.schema.json"
+      "$ref": "Types.Numeric.schema.json"
     },
     "exercise_price": {
       "description": "The exercise price of the warrant",
-      "type": "Types.Money.schema.json"
+      "$ref": "Types.Money.schema.json"
     },
     "purchase_price": {
       "description": "Actual purchase price of the warrant (sum up purported value of all consideration, including in-kind)",
-      "type": "Types.Money.schema.json"
+      "$ref": "Types.Money.schema.json"
     },
     "vesting": {
       "description": "Vesting conditions applicable to the warrant",
@@ -67,7 +67,7 @@
     },
     "expiration_date": {
       "description": "Expiration date of the warrant, if applicable",
-      "type": "Types.DateTime.schema.json"
+      "$ref": "Types.DateTime.schema.json"
     },
     "comments": {
       "title": "Warrant Issuance - Comments",

--- a/utils/validate.py
+++ b/utils/validate.py
@@ -18,12 +18,14 @@ from jsonschema import Draft7Validator, RefResolver, ValidationError, SchemaErro
 parent_dir = Path.cwd().parent
 snapshot_schema = parent_dir / "CapTable.schema.json"
 object_schema_dir = parent_dir / "objects"
+transactions_schema_dir = object_schema_dir / "transactions"
 type_schema_dir = parent_dir / "types"
 enum_schema_dir = parent_dir / "enums"
 
 schema_search_paths = [
     parent_dir.absolute(),
     object_schema_dir.absolute(),
+    transactions_schema_dir.absolute(),
     type_schema_dir.absolute(),
     enum_schema_dir.absolute()
 ]


### PR DESCRIPTION
When trying to run the test script with my other changes, I saw that:

1. transaction objects were not being loaded, and
2. the `WarrantIssuance` transaction had some minor errors