### PR TITLE
Added full list of sample transactions back into the new Transactions.ocf.json file. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate-docs": "jsonschema2md --input schema --out gen/docs -x -",
     "prepare": "husky install",
     "validate-ocf-file-schemas": "node ./utils/validate.mjs validate-ocf-schema -v -t",
-    "validate-example-ocf-files": "node ./utils/validate.mjs validate-ocf-directory -p ./tests/examples/files -v -t"
+    "validate-example-ocf-files": "node ./utils/validate.mjs validate-ocf-directory -p ./samples -v -t"
   },
   "devDependencies": {
     "@actions/core": "^1.6.0",

--- a/samples/Manifest.ocf.json
+++ b/samples/Manifest.ocf.json
@@ -1,0 +1,79 @@
+{
+  "ocf_version": "1.0.0-a3",
+  "file_type": "OCF_MANIFEST_FILE",
+  "issuer": {
+    "object_type": "ISSUER",
+    "id": "d3373e0a-4dd9-430f-8a56-3281f2800ede",
+    "legal_name": "ACME Industries",
+    "dba": "ACME & Co",
+    "formation_date": "2010-01-01",
+    "country_of_formation": "USA",
+    "state_of_formation": "DE",
+    "tax_ids": [
+      {
+        "tax_id": "34-2345123",
+        "country": "USA"
+      }
+    ],
+    "email": {
+      "email_address": "ceo@acme.io",
+      "email_type": "BUSINESS"
+    },
+    "phone": {
+      "phone_number": "16122342345",
+      "phone_type": "MOBILE"
+    },
+    "address": {
+      "address_type": "LEGAL",
+      "street_suite": "1234 Main Street\nSuite 4",
+      "city": "Small Town",
+      "state_province": "DE",
+      "country": "USA",
+      "postal_code": "12345"
+    },
+    "comments": []
+  },
+  "stock_plans_files": [
+    {
+      "filepath": "./StockPlans.json",
+      "md5": "c3e68dd645c6ab810f036923706355c8"
+    }
+  ],
+  "stock_legend_templates_files": [
+    {
+      "filepath": "./StockLegends.json",
+      "md5": "931d44dbd132cc09aef64ae4bab61987"
+    }
+  ],
+  "stock_classes_files": [
+    {
+      "filepath": "./StockClasses.json",
+      "md5": "45bbd5a565154f8c4a762c3d4fd711f1"
+    }
+  ],
+  "transactions_files": [
+    {
+      "filepath": "./Transactions.json",
+      "md5": "0e7757913b508d5cd8b06a578ac28848"
+    }
+  ],
+  "stakeholders_files": [
+    {
+      "filepath": "./Stakeholders.json",
+      "md5": "12c14ee9ac8e71a120cee15d075ecea6"
+    }
+  ],
+  "vesting_schedules_files": [
+    {
+      "filepath": "./VestingSchedules.json",
+      "md5": "a940c11797d285408a47b3a66535e090"
+    }
+  ],
+  "valuations_files": [
+    {
+      "filepath": "./Valuations.json",
+      "md5": "2a284a50fed8a0d07f10ed36edb14fc5"
+    }
+  ],
+  "comments": []
+}

--- a/samples/Stakeholders.ocf.json
+++ b/samples/Stakeholders.ocf.json
@@ -1,0 +1,23 @@
+{
+  "file_type": "OCF_STAKEHOLDERS_FILE",
+  "items": [
+    {
+      "object_type": "STAKEHOLDER",
+      "id": "aceb81e6-2d19-4ef2-ac53-05ff210d3508",
+      "name": {
+        "legal_name": "Person X",
+        "first_name": "Person",
+        "last_name": "X"
+      },
+      "stakeholder_type": "INDIVIDUAL",
+      "comments": []
+    },
+    {
+      "object_type": "STAKEHOLDER",
+      "id": "d6c49a5a-257d-4b41-9f1d-073a77dfe719",
+      "name": { "legal_name": "Person Y" },
+      "stakeholder_type": "INDIVIDUAL",
+      "comments": []
+    }
+  ]
+}

--- a/samples/StockClasses.ocf.json
+++ b/samples/StockClasses.ocf.json
@@ -1,0 +1,60 @@
+{
+  "file_type": "OCF_STOCK_CLASSES_FILE",
+  "items": [
+    {
+      "object_type": "STOCK_CLASS",
+      "id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
+      "name": "Common Stock",
+      "class_type": "COMMON",
+      "default_id_prefix": "CS-",
+      "current_shares_authorized": "1000000000.00",
+      "board_approval_date": "2001-02-28",
+      "votes_per_share": "1",
+      "par_value": {
+        "amount": "0.0001000000",
+        "currency": "USD"
+      },
+      "price_per_share": {
+        "amount": "0.0001000000",
+        "currency": "USD"
+      },
+      "seniority": "1",
+      "conversion_rights": [],
+      "liquidation_preference_multiple": "1",
+      "participation_cap_multiple": "1",
+      "comments": []
+    },
+    {
+      "object_type": "STOCK_CLASS",
+      "id": "cc775778-7d6e-4f8a-93cf-4df2242d7d6d",
+      "name": "Series Seed Preferred",
+      "class_type": "PREFERRED",
+      "default_id_prefix": "PS-",
+      "current_shares_authorized": "10000000.00",
+      "board_approval_date": "2021-01-28",
+      "votes_per_share": "1",
+      "par_value": {
+        "amount": "0.0001000000",
+        "currency": "USD"
+      },
+      "price_per_share": {
+        "amount": "2.4700000000",
+        "currency": "USD"
+      },
+      "seniority": "2",
+      "conversion_rights": [
+        {
+          "ratio": {
+            "antecedent": "1",
+            "consequent": "1"
+          },
+          "converts_to_stock_class_id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
+          "rounding_type": "NORMAL"
+        }
+      ],
+      "liquidation_preference_multiple": "2",
+      "participation_cap_multiple": "2",
+      "comments": []
+    }
+  ]
+}

--- a/samples/StockLegends.ocf.json
+++ b/samples/StockLegends.ocf.json
@@ -1,0 +1,4 @@
+{
+  "file_type": "OCF_STOCK_LEGEND_TEMPLATES_FILE",
+  "items": []
+}

--- a/samples/StockPlans.ocf.json
+++ b/samples/StockPlans.ocf.json
@@ -1,0 +1,16 @@
+{
+  "file_type": "OCF_STOCK_PLANS_FILE",
+  "items": [
+    {
+      "object_type": "STOCK_PLAN",
+      "id": "257e5da9-5268-465c-84be-f6d4d4703a9b",
+      "plan_name": "2021 Stock Incentive Plan",
+      "board_approval_date": "1983-12-31",
+      "current_shares_reserved": "+10000000.00",
+      "stock_class_id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
+      "comments": [
+        "Using new form of SOP released by Firm Y's benefits & comp team on 10/10/2021."
+      ]
+    }
+  ]
+}

--- a/samples/Transactions.ocf.json
+++ b/samples/Transactions.ocf.json
@@ -1,0 +1,843 @@
+{
+  "file_type": "OCF_TRANSACTIONS_FILE",
+  "items": [
+    {
+      "object_type": "TX_CONVERTIBLE_ACCEPTANCE",
+      "id": "test-convertible-acceptance-minimal",
+      "security_id": "2936wa8yefhdsvcn",
+      "date": "2022-01-20"
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_ACCEPTANCE",
+      "id": "test-convertible-acceptance-all-fields",
+      "security_id": "2936wa8yefhdsvcn",
+      "date": "2022-01-20",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_CANCELLATION",
+      "id": "test-convertible-cancellation-minimal",
+      "security_id": "asdf962w3hfsdad",
+      "date": "2019-01-31",
+      "amount": {
+        "amount": "53.09",
+        "currency": "USD"
+      },
+      "reason_text": "for testing"
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_CANCELLATION",
+      "id": "test-convertible-cancellation-all-fields",
+      "security_id": "test-security-id",
+      "date": "2019-01-31",
+      "amount": {
+        "amount": "53.09",
+        "currency": "USD"
+      },
+      "reason_text": "for testing",
+      "balance_security_id": "new-security",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_CONVERSION",
+      "id": "test-convertible-conversion-minimal",
+      "security_id": "b61c70c8-19a6-49c0-98f4-65f6c76b3841",
+      "date": "2006-11-09",
+      "reason_text": "for testing",
+      "resulting_security_ids": ["c349dcc8-cbf9-4ed9-88cd-9de4d0c8517c", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_CONVERSION",
+      "id": "test-convertible-conversion-all-fields",
+      "security_id": "b61c70c8-19a6-49c0-98f4-65f6c76b3841",
+      "date": "2006-11-09",
+      "reason_text": "for testing",
+      "resulting_security_ids": ["c349dcc8-cbf9-4ed9-88cd-9de4d0c8517c", "..."],
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_ISSUANCE",
+      "id": "test-convertible-issuance-minimal",
+      "security_id": "con_123456",
+      "date": "1978-05-27",
+      "security_law_exemptions": [],
+      "board_approval_date": "2022-01-01",
+      "stakeholder_id": "stk_567890",
+      "consideration": { "amount": "3.50", "currency": "USD" },
+      "custom_id": "CN-1",
+      "conversion_type": "PRE_MONEY",
+      "convertible_type": "NOTE",
+      "original_principal_amount": { "amount": "1000", "currency": "GBP" },
+      "day_count_convention": "ACTUAL_365",
+      "default_conversion_rights": {
+        "ratio": { "antecedent": "1", "consequent": "2.0" },
+        "rounding_type": "CEILING",
+        "converts_to_future_round": true
+      },
+      "conversion_triggers": [],
+      "seniority": 1
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_ISSUANCE",
+      "id": "test-convertible-issuance-all-fields",
+      "security_id": "con_123456",
+      "date": "1978-05-27",
+      "security_law_exemptions": [
+        {
+          "description": "Exemption",
+          "jurisdiction": "US"
+        }
+      ],
+      "board_approval_date": "2022-01-01",
+      "stakeholder_id": "stk_567890",
+      "consideration": { "amount": "3.50", "currency": "USD" },
+      "custom_id": "CN-1",
+      "conversion_type": "POST_MONEY",
+      "convertible_type": "SAFE",
+      "original_principal_amount": { "amount": "1000", "currency": "GBP" },
+      "day_count_convention": "30_360",
+      "default_conversion_rights": {
+        "ratio": { "antecedent": "1", "consequent": "2.0" },
+        "rounding_type": "FLOOR",
+        "converts_to_stock_class_id": "cls_86"
+      },
+      "conversion_triggers": [
+        {
+          "rounding_type": "NORMAL",
+          "description": "Trigger",
+          "converts_to_future_round": false
+        }
+      ],
+      "seniority": 1,
+      "interest_rate": "3.11",
+      "interest_payout": "CASH",
+      "maturity_date": "2034-01-01",
+      "exit_multiple": { "antecedent": "1", "consequent": "3.0" },
+      "interest_accrual_period": "MONTHLY",
+      "compounding_type": "SIMPLE",
+      "pro_rata": "2500",
+      "conversion_valuation_cap": { "amount": "8000000", "currency": "USD" },
+      "conversion_discount": "0.1",
+      "conversion_fixed_ownership": "0.05",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_RETRACTION",
+      "id": "test-convertible-retraction-minimal",
+      "security_id": "test-convertible-retraction",
+      "date": "2021-01-14",
+      "reason_text": "oops"
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_RETRACTION",
+      "id": "test-convertible-retraction-all-fields",
+      "security_id": "test-convertible-retraction",
+      "date": "2021-01-14",
+      "reason_text": "oops",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_TRANSFER",
+      "id": "test-convertible-transfer-minimal",
+      "security_id": "test-security-id",
+      "date": "2018-06-07",
+      "resulting_security_ids": ["new-security-1", "..."],
+      "amount": {
+        "amount": "-867.53",
+        "currency": "USD"
+      }
+    },
+    {
+      "object_type": "TX_CONVERTIBLE_TRANSFER",
+      "id": "test-convertible-transfer-all-fields",
+      "security_id": "test-security-id",
+      "date": "2018-06-07",
+      "resulting_security_ids": ["new-security-1", "..."],
+      "amount": {
+        "amount": "-867.53",
+        "currency": "USD"
+      },
+      "consideration": { "amount": "3.50", "currency": "USD" },
+      "balance_security_id": "test-security-id-2",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_ACCEPTANCE",
+      "id": "test-plan-security-acceptance-minimal",
+      "security_id": "test-security-id",
+      "date": "2019-12-10"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_ACCEPTANCE",
+      "id": "test-plan-security-acceptance-all-fields",
+      "security_id": "test-security-id",
+      "date": "2019-12-10",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_CANCELLATION",
+      "id": "test-plan-security-cancellation-minimal",
+      "security_id": "test-security-id",
+      "date": "2019-12-11",
+      "reason_text": "need to cancel",
+      "quantity": "100"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_CANCELLATION",
+      "id": "test-plan-security-cancellation-all-fields",
+      "security_id": "test-security-id",
+      "date": "2019-12-11",
+      "reason_text": "need to cancel",
+      "quantity": "100",
+      "balance_security_id": "test-balance-security-id",
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_EXERCISE",
+      "id": "test-plan-security-exercise-minimal",
+      "security_id": "test-security-id",
+      "date": "2019-12-12",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "quantity": "100"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_EXERCISE",
+      "id": "test-plan-security-exercise-full-fields",
+      "security_id": "test-security-id",
+      "date": "2019-12-12",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "quantity": "100",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "comments": ["comment-one", "comment-two", "..."]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_ISSUANCE",
+      "id": "test-plan-security-issuance-minimal",
+      "security_id": "test-security-id",
+      "date": "2019-12-12",
+      "security_law_exemptions": [
+        {
+          "description": "Exemption",
+          "jurisdiction": "CA"
+        }
+      ],
+      "board_approval_date": "2021-01-21",
+      "stakeholder_id": "test-stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "custom_id": "CA-1",
+      "stock_plan_id": "test-stock-plan-id",
+      "compensation_type": "RSU",
+      "quantity": "50",
+      "exercise_price": { "amount": "50.00", "currency": "USD" },
+      "vesting_rules": {
+        "vesting_type": "SCHEDULE_DRIVEN_ONLY"
+      },
+      "expiration_date": "2031-01-20",
+      "termination_exercise_windows": [
+        {
+          "reason": "CAUSE",
+          "period": 1,
+          "period_type": "DAYS"
+        }
+      ]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_ISSUANCE",
+      "id": "test-plan-security-issuance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2019-12-12",
+      "security_law_exemptions": [
+        {
+          "description": "Exemption",
+          "jurisdiction": "CA"
+        },
+        {
+          "description": "Extra special exemption",
+          "jurisdiction": "CA"
+        }
+      ],
+      "board_approval_date": "2021-01-21",
+      "stakeholder_id": "test-stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "CAD" },
+      "custom_id": "CA-1",
+      "stock_plan_id": "test-stock-plan-id",
+      "compensation_type": "RSU",
+      "quantity": "100",
+      "exercise_price": { "amount": "50.00", "currency": "CAD" },
+      "vesting_rules": {
+        "vesting_type": "SCHEDULE_DRIVEN_ONLY",
+        "vesting_schedule_id": "test-vesting-schedule-id",
+        "vesting_start_date": "2021-01-10",
+        "vesting_conditions": [
+          {
+            "amount_numerator": 1,
+            "amount_denominator": 4,
+            "period_length": 1,
+            "period_type": "YEARS",
+            "priority": 1,
+            "dependent_vesting": []
+          }
+        ],
+        "custom_vesting_tranches": [
+          {
+            "vest_date": "2021-01-11",
+            "vest_quantity": "100"
+          }
+        ],
+        "custom_vesting_description": "100% up front due to custom vesting tranche"
+      },
+      "expiration_date": "2031-01-20",
+      "termination_exercise_windows": [
+        {
+          "reason": "CAUSE",
+          "period": 0,
+          "period_type": "DAYS"
+        },
+        {
+          "reason": "VOLUNTARY",
+          "period": 3,
+          "period_type": "MONTHS"
+        },
+        {
+          "reason": "INVOLUNTARY",
+          "period": 14,
+          "period_type": "DAYS"
+        },
+        {
+          "reason": "DEATH",
+          "period": 3,
+          "period_type": "YEARS"
+        },
+        {
+          "reason": "DISABILITY",
+          "period": 3,
+          "period_type": "YEARS"
+        },
+        {
+          "reason": "RETIREMENT",
+          "period": 1,
+          "period_type": "MONTHS"
+        }
+      ],
+      "comments": ["comment 1", "comment 2", "a third comment"]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_RELEASE",
+      "id": "test-plan-security-release-minimal",
+      "security_id": "387878ba-8fb6-4673-812e-32c092947899",
+      "date": "2017-07-22",
+      "settlement_date": "2017-07-22",
+      "release_price": { "amount": "9.00", "currency": "CAD" }
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_RELEASE",
+      "id": "test-plan-security-release-full-fields",
+      "security_id": "387878ba-8fb6-4673-812e-32c092947899",
+      "date": "2017-07-22",
+      "settlement_date": "2017-07-22",
+      "release_price": { "amount": "9.00", "currency": "CAD" },
+      "comments": ["Release the securities"],
+      "net_quantity": "42",
+      "method": "Method of release",
+      "stock_swap": false,
+      "cash_paid": { "amount": "0.00", "currency": "CAD" },
+      "quantity_sold": "1",
+      "sale_price_per_unit": { "amount": "0.00", "currency": "CAD" },
+      "withheld_quantity": "0"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_RETRACTION",
+      "id": "test-plan-security-retraction-minimal",
+      "security_id": "0f96b82a-6dc5-4205-bcb1-15740e5f8304",
+      "date": "2022-01-24",
+      "reason_text": "We wish to make a retraction"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_RETRACTION",
+      "id": "test-plan-security-retraction-full-fields",
+      "security_id": "0f96b82a-6dc5-4205-bcb1-15740e5f8304",
+      "date": "2022-01-24",
+      "reason_text": "We wish to make a retraction",
+      "comments": ["A", "Series", "Of", "Comments"]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_SPLIT",
+      "id": "test-plan-security-split-minimal",
+      "security_id": "1",
+      "date": "2022-01-01",
+      "resulting_security_ids": ["2", "3"],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      }
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_SPLIT",
+      "id": "test-plan-security-split-full-fields",
+      "security_id": "1",
+      "date": "2022-01-01",
+      "resulting_security_ids": ["2", "3"],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      },
+      "comments": ["One comment", "A second comment"]
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_TRANSFER",
+      "id": "test-plan-security-transfer-minimal",
+      "security_id": "0zHLfmI9G0",
+      "date": "2001-01-01",
+      "resulting_security_ids": ["eiO9qSCztZ", "feit2eP2NQ"],
+      "quantity": "11"
+    },
+    {
+      "object_type": "TX_PLAN_SECURITY_TRANSFER",
+      "id": "test-plan-security-transfer-full-fields",
+      "security_id": "0zHLfmI9G0",
+      "date": "2001-01-01",
+      "resulting_security_ids": ["eiO9qSCztZ", "feit2eP2NQ"],
+      "quantity": "11",
+      "comments": ["Comment"],
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "balance_security_id": "fyLFexlMGV"
+    },
+    {
+      "object_type": "TX_STOCK_ACCEPTANCE",
+      "id": "test-stock-acceptance-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01"
+    },
+    {
+      "object_type": "TX_STOCK_ACCEPTANCE",
+      "id": "test-stock-acceptance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_STOCK_CANCELLATION",
+      "id": "test-stock-cancellation-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Cancel the securities",
+      "quantity": "37"
+    },
+    {
+      "object_type": "TX_STOCK_CANCELLATION",
+      "id": "test-stock-cancellation-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Cancel the securities",
+      "quantity": "37",
+      "comments": ["Here is a comment", "Here is another comment"],
+      "balance_security_id": "test-balance-security-id"
+    },
+    {
+      "object_type": "TX_STOCK_CONVERSION",
+      "id": "test-stock-conversion-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": ["resultant-security-id-1"],
+      "quantity_converted": "1",
+      "conversion_ratio": {
+        "antecedent": "1",
+        "consequent": "1"
+      }
+    },
+    {
+      "object_type": "TX_STOCK_CONVERSION",
+      "id": "test-stock-conversion-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ],
+      "quantity_converted": "10",
+      "conversion_ratio": {
+        "antecedent": "1",
+        "consequent": "3"
+      },
+      "comments": ["Here is a comment", "Here is another comment"],
+      "balance_security_id": "balance-security-id"
+    },
+    {
+      "object_type": "TX_STOCK_SPLIT",
+      "id": "test-quantity-split",
+      "security_id": "test-security-id",
+      "resulting_security_ids": ["new-security-1", "new-security-2"],
+      "date": "2022-01-17",
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      }
+    },
+    {
+      "object_type": "TX_STOCK_ISSUANCE",
+      "id": "test-stock-issuance-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "security_law_exemptions": [],
+      "board_approval_date": "2022-02-01",
+      "stakeholder_id": "stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "custom_id": "S-1",
+      "stock_class_id": "stock-class-id",
+      "share_price": { "amount": "1.00", "currency": "USD" },
+      "quantity": "1000",
+      "cost_basis": { "amount": "0", "currency": "USD" },
+      "stock_legend_ids": ["stock-legend-id-1", "stock-legend-id-2"],
+      "issued_from_parent_object": {
+        "parent_object_type": "STOCK",
+        "parent_object_id": "parent-object-id"
+      }
+    },
+    {
+      "object_type": "TX_STOCK_ISSUANCE",
+      "id": "test-stock-issuance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "security_law_exemptions": [
+        {
+          "description": "Exemption",
+          "jurisdiction": "USA"
+        }
+      ],
+      "board_approval_date": "2022-02-01",
+      "stakeholder_id": "stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "custom_id": "S-1",
+      "stock_class_id": "stock-class-id",
+      "share_price": { "amount": "1.00", "currency": "USD" },
+      "quantity": "1000",
+      "cost_basis": { "amount": "0", "currency": "USD" },
+      "stock_legend_ids": ["stock-legend-id-1", "stock-legend-id-2"],
+      "issued_from_parent_object": {
+        "parent_object_type": "STOCK",
+        "parent_object_id": "parent-object-id"
+      },
+      "comments": ["Here is a comment", "Here is another comment"],
+      "vesting_rules": {
+        "vesting_type": "SCHEDULE_DRIVEN_ONLY",
+        "vesting_schedule_id": "test-vesting-schedule-id",
+        "vesting_start_date": "2021-01-10",
+        "vesting_conditions": [
+          {
+            "amount_numerator": 1,
+            "amount_denominator": 4,
+            "period_length": 1,
+            "period_type": "YEARS",
+            "priority": 1,
+            "dependent_vesting": []
+          }
+        ]
+      }
+    },
+    {
+      "object_type": "TX_STOCK_REISSUANCE",
+      "id": "test-stock-reissuance-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ]
+    },
+    {
+      "object_type": "TX_STOCK_REISSUANCE",
+      "id": "test-stock-reissuance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ],
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_STOCK_REPURCHASE",
+      "id": "test-stock-repurchase-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "price": { "amount": "3.00", "currency": "USD" },
+      "quantity": "33",
+      "consideration": { "amount": "3.00", "currency": "CAD" }
+    },
+    {
+      "object_type": "TX_STOCK_REPURCHASE",
+      "id": "test-stock-repurchase-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "price": { "amount": "3.00", "currency": "USD" },
+      "quantity": "33",
+      "consideration": { "amount": "3.00", "currency": "CAD" },
+      "comments": ["Here is a comment", "Here is another comment"],
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ]
+    },
+    {
+      "object_type": "TX_STOCK_RETRACTION",
+      "id": "test-stock-retraction-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Retract the stocks"
+    },
+    {
+      "object_type": "TX_STOCK_RETRACTION",
+      "id": "test-stock-retraction-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Retract the stocks",
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_STOCK_SPLIT",
+      "id": "test-stock-split-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      }
+    },
+    {
+      "object_type": "TX_STOCK_SPLIT",
+      "id": "test-stock-split-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      },
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_STOCK_TRANSFER",
+      "id": "test-stock-transfer-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ],
+      "quantity": "10"
+    },
+    {
+      "object_type": "TX_STOCK_TRANSFER",
+      "id": "test-stock-transfer-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2",
+        "resultant-security-id-3"
+      ],
+      "quantity": "10",
+      "comments": ["Here is a comment", "Here is another comment"],
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "balance_security_id": "balance-security-id"
+    },
+    {
+      "object_type": "TX_WARRANT_ACCEPTANCE",
+      "id": "test-warrant-acceptance-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01"
+    },
+    {
+      "object_type": "TX_WARRANT_ACCEPTANCE",
+      "id": "test-warrant-acceptance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_WARRANT_CANCELLATION",
+      "id": "test-warrant-cancellation-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Warrant needs to be cancelled",
+      "quantity": "1000"
+    },
+    {
+      "object_type": "TX_WARRANT_CANCELLATION",
+      "id": "test-warrant-cancellation-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Warrant needs to be cancelled",
+      "quantity": "1000",
+      "comments": ["Here is a comment", "Here is another comment"],
+      "balance_security_id": "balance-security-id"
+    },
+    {
+      "object_type": "TX_WARRANT_EXERCISE",
+      "id": "test-warrant-exercise-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ]
+    },
+    {
+      "object_type": "TX_WARRANT_EXERCISE",
+      "id": "test-warrant-exercise-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "comments": ["Here is a comment", "Here is another comment"],
+      "consideration": { "amount": "1.23", "currency": "USD" }
+    },
+    {
+      "object_type": "TX_WARRANT_ISSUANCE",
+      "id": "test-warrant-issuance-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "security_law_exemptions": [],
+      "board_approval_date": "2022-02-01",
+      "stakeholder_id": "stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "custom_id": "S-1",
+      "quantity": "1000",
+      "conversion_rights": [],
+      "purchase_price": { "amount": "1.00", "currency": "USD" },
+      "exercise_price": { "amount": "1.00", "currency": "USD" }
+    },
+    {
+      "object_type": "TX_WARRANT_ISSUANCE",
+      "id": "test-warrant-issuance-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "security_law_exemptions": [
+        {
+          "description": "Exemption",
+          "jurisdiction": "USA"
+        }
+      ],
+      "board_approval_date": "2022-02-01",
+      "stakeholder_id": "stakeholder-id",
+      "consideration": { "amount": "1.00", "currency": "USD" },
+      "custom_id": "S-1",
+      "quantity": "1000",
+      "conversion_rights": [
+        {
+          "converts_to_stock_class_id": "stock-class-id",
+          "ratio": {
+            "antecedent": "1",
+            "consequent": "10"
+          },
+          "rounding_type": "CEILING"
+        }
+      ],
+      "purchase_price": { "amount": "1.00", "currency": "USD" },
+      "exercise_price": { "amount": "1.00", "currency": "USD" },
+      "comments": ["Here is a comment", "Here is another comment"],
+      "vesting_rules": {
+        "vesting_type": "SCHEDULE_DRIVEN_ONLY",
+        "vesting_schedule_id": "test-vesting-schedule-id",
+        "vesting_start_date": "2021-01-10",
+        "vesting_conditions": [
+          {
+            "amount_numerator": 1,
+            "amount_denominator": 4,
+            "period_length": 1,
+            "period_type": "YEARS",
+            "priority": 1,
+            "dependent_vesting": []
+          }
+        ]
+      },
+      "expiration_date": "2032-02-01"
+    },
+    {
+      "object_type": "TX_WARRANT_RETRACTION",
+      "id": "test-warrant-retraction-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Need to retract"
+    },
+    {
+      "object_type": "TX_WARRANT_RETRACTION",
+      "id": "test-warrant-retraction-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "reason_text": "Need to retract",
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_WARRANT_SPLIT",
+      "id": "test-warrant-split-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      }
+    },
+    {
+      "object_type": "TX_WARRANT_SPLIT",
+      "id": "test-warrant-split-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "split_ratio": {
+        "antecedent": "1",
+        "consequent": "2"
+      },
+      "comments": ["Here is a comment", "Here is another comment"]
+    },
+    {
+      "object_type": "TX_WARRANT_TRANSFER",
+      "id": "test-warrant-transfer-minimal",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": ["resultant-security-id-1"],
+      "quantity": "10000"
+    },
+    {
+      "object_type": "TX_WARRANT_TRANSFER",
+      "id": "test-warrant-transfer-full-fields",
+      "security_id": "test-security-id",
+      "date": "2022-02-01",
+      "resulting_security_ids": [
+        "resultant-security-id-1",
+        "resultant-security-id-2"
+      ],
+      "quantity": "10000",
+      "comments": ["Here is a comment", "Here is another comment"],
+      "consideration": { "amount": "0.50", "currency": "USD" },
+      "balance_security_id": "balance-security-id"
+    }
+  ]
+}

--- a/samples/Valuations.ocf.json
+++ b/samples/Valuations.ocf.json
@@ -1,0 +1,4 @@
+{
+  "file_type": "OCF_VALUATIONS_FILE",
+  "items": []
+}

--- a/samples/VestingSchedules.ocf.json
+++ b/samples/VestingSchedules.ocf.json
@@ -1,0 +1,29 @@
+{
+  "file_type": "OCF_VESTING_SCHEDULES_FILE",
+  "items": [
+    {
+      "id": "d3d756f3-0cd9-40c7-80dd-6aced7c7d93c",
+      "object_type": "VESTING_SCHEDULE",
+      "name": "Four Year / One Year Cliff",
+      "description": "25% of the total number of shares shall vest on the one-year anniversary of this Agreement, and an additional 1/48th of the total number of Shares shall then vest on the corresponding day of each month thereafter, until all of the Shares have been released on the fourth anniversary of this Agreement.",
+      "allocation_type": "CUMULATIVE_ROUNDING",
+      "fractional_tranches_allowed": false,
+      "schedule_driven_vesting_conditions": [
+        {
+          "amount_numerator": 12,
+          "amount_denominator": 48,
+          "period_length": 1,
+          "period_type": "YEARS",
+          "dependent_vesting:": [
+            {
+              "amount_numerator": 1,
+              "amount_denominator": 48,
+              "period_length": 1,
+              "period_type": "MONTHS"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added Patrick and Tyler's transaction examples back in. Closes #29 and #81. Also restructured the files so they're not in a sample folder instead of buried in a sub-folder of tests. We can add a tests folder once we select a testing package, but we should probably keep the actual sample data elsewhere. Certainly we don't want it as nested as it ended up being before. 