### PR TITLE
Add some Github niceties

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* Open-Cap-Table-Coalition/twg

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: Report a bug encountered with the Open Cap Table Format (OCF)
+labels: kind/bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: OCF Support Request
+    url: https://opencaptablecoalition.com
+    about: Support request or question relating to the Open Cap Table Format (OCF)

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,17 @@
+name: Enhancement Tracking Issue
+description: Provide supporting details for a feature in development
+labels: kind/feature
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/failing-test.yaml
+++ b/.github/ISSUE_TEMPLATE/failing-test.yaml
@@ -1,0 +1,27 @@
+name: Failing Test
+description: Report continuously failing tests
+labels: kind/failing-test
+body:
+  - type: textarea
+    id: tests
+    attributes:
+      label: Which tests are failing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: since
+    attributes:
+      label: Since when has it been failing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason for failure (if possible)
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. Read the [contributing guidelines](../docs/CONTRIBUTING.md).
+2. Ensure you have added or ran the appropriate tests for your PR.
+3. If your PR is unfinished, consider creating a [Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
+-->
+
+#### What type of PR is this?
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+
+Optionally add one or more of the following kinds if applicable:
+/kind deprecation
+/kind failing-test
+/kind regression
+-->
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+
+<!--
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+
+Fixes #

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-node_modules/
-__pycache__/
+# Mac
+.DS_Store
 
+# IDE files
+.vscode
+.idea
+
+# Node
+node_modules

--- a/gen/docs/README.md
+++ b/gen/docs/README.md
@@ -216,7 +216,15 @@
 
 ### Objects
 
+*   [Type - Email](./contactinfo-properties-contact-info---email-address-array-type---email.md "Type representation of an email address") – `https://opencaptablecoalition.com/schema/types/email#/properties/emails/items`
 
+*   [Type - Name](./contactinfo-properties-type---name.md "Type comprising of multiple name components") – `https://opencaptablecoalition.com/schema/types/name#/properties/name`
+
+*   [Type - Phone](./contactinfo-properties-contact-info---phone-number-array-type---phone.md "Type representation of a phone number") – `https://opencaptablecoalition.com/schema/types/phone#/properties/phone_numbers/items`
+
+*   [Type - Ratio](./conversiontrigger-properties-type---ratio.md "Type representation of a ratio as antecedent and consequent numeric values") – `https://opencaptablecoalition.com/schema/types/ratio#/properties/ratio`
+
+*   [Type - Schedule-driven Vesting Condition](./eventdrivenvestingcondition-properties-event-driven-vesting-condition---event-driven-vesting-condition-array-items-anyof-type---schedule-driven-vesting-condition.md "Type representation of a row in a vesting schedule") – `https://opencaptablecoalition.com/schema/types/schedule_driven_vesting_condition#/properties/dependent_vesting/items/anyOf/1`
 
 ### Arrays
 


### PR DESCRIPTION
Addresses issue https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/issues/87

## Summary

Add some Gitub niceties to make it easier to interact with the repo:
* Make the `Open-Cap-Table-Coalition/twg` Github team codeowners of the entire repo
  * Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
* Add issue templates using issue forms for bug reports, enhancements, and failing tests
  * Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
* Configure issue template chooser through `config.yml`
  * Docs: https://docs.github.com/en/enterprise-server@3.0/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
* Add PR template
  * Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

Also update `.gitignore` to include some common files