### PR TITLE
Rename the properties of the Ratio schema to numerator and denominator, and flip the values in all examples

### DIFF
--- a/samples/StockClasses.ocf.json
+++ b/samples/StockClasses.ocf.json
@@ -45,8 +45,8 @@
       "conversion_rights": [
         {
           "ratio": {
-            "antecedent": "1",
-            "consequent": "1"
+            "numerator": "1",
+            "denominator": "1"
           },
           "converts_to_stock_class_id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
           "rounding_type": "NORMAL"

--- a/samples/Transactions.ocf.json
+++ b/samples/Transactions.ocf.json
@@ -70,7 +70,7 @@
       "original_principal_amount": { "amount": "1000", "currency": "GBP" },
       "day_count_convention": "ACTUAL_365",
       "default_conversion_rights": {
-        "ratio": { "antecedent": "1", "consequent": "2.0" },
+        "ratio": { "numerator": "2.0", "denominator": "1" },
         "rounding_type": "CEILING",
         "converts_to_future_round": true
       },
@@ -97,7 +97,7 @@
       "original_principal_amount": { "amount": "1000", "currency": "GBP" },
       "day_count_convention": "30_360",
       "default_conversion_rights": {
-        "ratio": { "antecedent": "1", "consequent": "2.0" },
+        "ratio": { "numerator": "2.0", "denominator": "1" },
         "rounding_type": "FLOOR",
         "converts_to_stock_class_id": "cls_86"
       },
@@ -112,7 +112,7 @@
       "interest_rate": "3.11",
       "interest_payout": "CASH",
       "maturity_date": "2034-01-01",
-      "exit_multiple": { "antecedent": "1", "consequent": "3.0" },
+      "exit_multiple": { "numerator": "3.0", "denominator": "1" },
       "interest_accrual_period": "MONTHLY",
       "compounding_type": "SIMPLE",
       "pro_rata": "2500",
@@ -373,8 +373,8 @@
       "date": "2022-01-01",
       "resulting_security_ids": ["2", "3"],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       }
     },
     {
@@ -384,8 +384,8 @@
       "date": "2022-01-01",
       "resulting_security_ids": ["2", "3"],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       },
       "comments": ["One comment", "A second comment"]
     },
@@ -447,8 +447,8 @@
       "resulting_security_ids": ["resultant-security-id-1"],
       "quantity_converted": "1",
       "conversion_ratio": {
-        "antecedent": "1",
-        "consequent": "1"
+        "numerator": "1",
+        "denominator": "1"
       }
     },
     {
@@ -463,8 +463,8 @@
       ],
       "quantity_converted": "10",
       "conversion_ratio": {
-        "antecedent": "1",
-        "consequent": "3"
+        "numerator": "3",
+        "denominator": "1"
       },
       "comments": ["Here is a comment", "Here is another comment"],
       "balance_security_id": "balance-security-id"
@@ -476,8 +476,8 @@
       "resulting_security_ids": ["new-security-1", "new-security-2"],
       "date": "2022-01-17",
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       }
     },
     {
@@ -613,8 +613,8 @@
         "resultant-security-id-2"
       ],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       }
     },
     {
@@ -627,8 +627,8 @@
         "resultant-security-id-2"
       ],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       },
       "comments": ["Here is a comment", "Here is another comment"]
     },
@@ -747,8 +747,8 @@
         {
           "converts_to_stock_class_id": "stock-class-id",
           "ratio": {
-            "antecedent": "1",
-            "consequent": "10"
+            "numerator": "10",
+            "denominator": "1"
           },
           "rounding_type": "CEILING"
         }
@@ -798,8 +798,8 @@
         "resultant-security-id-2"
       ],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       }
     },
     {
@@ -812,8 +812,8 @@
         "resultant-security-id-2"
       ],
       "split_ratio": {
-        "antecedent": "1",
-        "consequent": "2"
+        "numerator": "2",
+        "denominator": "1"
       },
       "comments": ["Here is a comment", "Here is another comment"]
     },

--- a/schema/types/Ratio.schema.json
+++ b/schema/types/Ratio.schema.json
@@ -2,17 +2,17 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://opencaptablecoalition.com/schema/types/Ratio.schema.json",
   "title": "Type - Ratio",
-  "description": "Type representation of a ratio as antecedent and consequent numeric values",
+  "description": "Type representation of a ratio as two parts of a quotient, i.e. numerator and denominator numeric values",
   "type": "object",
   "properties": {
-    "antecedent": {
-      "description": "Antecedent value of ratio (e.g. in a:b, a is the antecedent)",
+    "numerator": {
+      "description": "Numerator of the ratio, i.e. the ratio of A to B (A:B) can be expressed as a fraction (A/B), where A is the numerator",
       "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
     },
-    "consequent": {
-      "description": "Consequent value of ratio (e.g. in a:b, b is the consequent)",
+    "denominator": {
+      "description": "Denominator of the ratio, i.e. the ratio of A to B (A:B) can be expressed as a fraction (A/B), where B is the denominator",
       "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
     }
   },
-  "required": ["antecedent", "consequent"]
+  "required": ["numerator", "denominator"]
 }

--- a/tests/examples/files/StockClasses.ocf.json
+++ b/tests/examples/files/StockClasses.ocf.json
@@ -45,8 +45,8 @@
       "conversion_rights": [
         {
           "ratio": {
-            "antecedent": "1",
-            "consequent": "1"
+            "numerator": "1",
+            "denominator": "1"
           },
           "converts_to_stock_class_id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
           "rounding_type": "NORMAL"

--- a/tests/examples/files/Transactions.ocf.json
+++ b/tests/examples/files/Transactions.ocf.json
@@ -41,7 +41,7 @@
       "security_id": "test-security-id",
       "resulting_security_ids": ["new-security-1", "new-security-2"],
       "date": "2022-01-17",
-      "split_ratio": { "antecedent": "1", "consequent": "2" }
+      "split_ratio": { "numerator": "2", "denominator": "1" }
     },
     {
       "object_type": "TX_STOCK_TRANSFER",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
It was agreed that the nomenclature of antecedent and consequent was causing confusion, as it could be implied that the consequent is the "afterwards" number (e.g. in the context of a stock split, the consequent representing the "new shares"). This is not actually true, because in business terms a ratio of 2:1 is taken to mean "2 new shares for 1 old share"

#### Which issue(s) this PR fixes:

Fixes #136
