### PR TITLE
Change License to Reflect JSON Schema $comment

### DIFF
--- a/License.MD
+++ b/License.MD
@@ -17,7 +17,7 @@ royalty is hereby granted, provided that
   - A notice in the form "Copyright © [$date-of-ocf-file] [Open Cap Table Coalition](https://opencaptablecoalition.com)."; and
 2) For _ALL_ copies of an OCF File or portions thereof that **are** JSON Schema files, you include
   - A `$comment` field with a value of: "Copyright © [$date-of-ocf-file] 
-  Open Cap Table Coalition (https://opencaptablecoalition.com) - Original File: [$url-of-original-schema-file]."
+  Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: [$url-of-original-schema-file]"
 
 When space permits, inclusion of the full text of this **NOTICE** should be provided. We request 
 that authorship attribution be provided in any software, documents, or other items or products 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

As discussed, the only way to drop a notice into the JSON Schema files is to use a `$comment` keyword / field. I updated the license to reflect that the copyright notices should be different in a JSON Schema file vs other "OCF Files" (basically all documentation that's not a JSON Schema file.

#### Which issue(s) this PR fixes:

N/A
