### PR TITLE
[Enhancement] - Conversion PR 2 of 5: Remove `Conversion_ratio` from StockConversion Objs

### DIFF
--- a/docs/schema/objects/transactions/conversion/StockConversion.md
+++ b/docs/schema/objects/transactions/conversion/StockConversion.md
@@ -29,7 +29,6 @@
 | resulting_security_ids | [`STRING`]                                                                                                       | Identifier for the security (or securities) that resulted from the conversion                                                                                                                                                                                                                                                                                                                                                                                                                               | `REQUIRED` |
 | balance_security_id    | `STRING`                                                                                                         | Identifier for the security that holds the remainder balance (for partial conversions)                                                                                                                                                                                                                                                                                                                                                                                                                      | -          |
 | quantity_converted     | [schema/types/Numeric](/docs/schema/types/Numeric.md)                                                            | Quantity of non-monetary security units converted                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `REQUIRED` |
-| conversion_ratio       | [schema/types/Ratio](/docs/schema/types/Ratio.md)                                                                | Quantity of non-monetary security units converted                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `REQUIRED` |
 
 **Source Code:** [schema/objects/transactions/conversion/StockConversion](/schema/objects/transactions/conversion/StockConversion.schema.json)
 
@@ -45,11 +44,7 @@
     "resulting_security_ids": [
       "resultant-security-id-1"
     ],
-    "quantity_converted": "1",
-    "conversion_ratio": {
-      "numerator": "1",
-      "denominator": "1"
-    }
+    "quantity_converted": "1"
   },
   {
     "object_type": "TX_STOCK_CONVERSION",
@@ -62,10 +57,6 @@
       "resultant-security-id-3"
     ],
     "quantity_converted": "10",
-    "conversion_ratio": {
-      "numerator": "3",
-      "denominator": "1"
-    },
     "comments": [
       "Here is a comment",
       "Here is another comment"

--- a/samples/Transactions.ocf.json
+++ b/samples/Transactions.ocf.json
@@ -454,11 +454,7 @@
       "security_id": "test-security-id",
       "date": "2022-02-01",
       "resulting_security_ids": ["resultant-security-id-1"],
-      "quantity_converted": "1",
-      "conversion_ratio": {
-        "numerator": "1",
-        "denominator": "1"
-      }
+      "quantity_converted": "1"
     },
     {
       "object_type": "TX_STOCK_CONVERSION",
@@ -471,10 +467,6 @@
         "resultant-security-id-3"
       ],
       "quantity_converted": "10",
-      "conversion_ratio": {
-        "numerator": "3",
-        "denominator": "1"
-      },
       "comments": ["Here is a comment", "Here is another comment"],
       "balance_security_id": "balance-security-id"
     },

--- a/schema/objects/transactions/conversion/StockConversion.schema.json
+++ b/schema/objects/transactions/conversion/StockConversion.schema.json
@@ -30,10 +30,6 @@
       "description": "Quantity of non-monetary security units converted",
       "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
     },
-    "conversion_ratio": {
-      "description": "Quantity of non-monetary security units converted",
-      "$ref": "https://opencaptablecoalition.com/schema/types/Ratio.schema.json"
-    },
     "id": {},
     "comments": {},
     "security_id": {},
@@ -41,6 +37,6 @@
     "resulting_security_ids": {}
   },
   "additionalProperties": false,
-  "required": ["quantity_converted", "conversion_ratio"],
+  "required": ["quantity_converted"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/conversion/StockConversion.schema.json"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Per TWG discussion on 4/12/22, conversion ratios, if that's indeed how conversion amount is determined, should be implicit if you trace the event stack. Moreover, the StockClass objs have 'StockClassConversionRights' types attached to them which set forth the conversion rights and ratios for that class. So, the current StockConversion obj doesn't follow our preferred approach AND duplicates existing data stored at the class level. Removing the duplicated field as part of a larger project to streamline and enhance conversion handling. 

#### Which issue(s) this PR fixes:
 
None opened.