### PR TITLE
Fix Generated Docs Linting Issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
-npm run enforce-copyright-notices && npm run fix && git add schema
+npm run enforce-copyright-notices && git add schema
 npm run generate-docs && git add docs/schema && git add README.md
+npx lint-staged


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As noted in Issue #173, a bunch of my branches were failing the linting check due to errors in the generated markdown. That was super weird, because I had intentionally run `npm run fix` to force prettier to fix everything and it was passing locally. 

With @pjohnmeyer's help, was able to trace what's causing this behavior.   

**Here's what was happening:**

1. When i would commit changes locally, husky kicks off the pre-commit actions. The linter runs first. So far so good. 
2. OCF `$comment` fields and docs are generated. 
3. With numbered lists, the Markdown output apparently needs tweaks to satisfy linting. Linting ran before the docs were generated, however. So, as a result, once these changes are staged and pushed to a branch, that branch fails linting checks. 
4. Now, normally, this could be fixed manually or on a subsequent commit, _but_, in this case, the way we generate docs and apply linting makes it impossible to do this. 
5. When you commit the next set of changes or manually run `npm run fix` on the this failing branch, prettier runs and finds the MD problem from last time and fixes it. Great. 
6. When husky's doc generation pre-commit action kicks in again, however, it recreates the markdown prettier just fixed and commits the now re-broken markdown on top of the prettified markdown. This is how I'd had empty commits that were, in theory meant to fix these issue. If your only change is to run `npm run fix` to manually fix linting issues and you then commit those changes, the doc generator will blow up those changes when it runs as a pre-commit action.

For now, it appears the fix is to run npx lint-stage **last** in the pre-commit action. We also removed the npm run fix command after the `$comment` field is added as npx lint-stage does the same thing and, if it's run last, there's no reason to run prettier twice.

Another options is potentially to ignore markdown outputs when running prettier, but we probably don't want to do that. 

#### Which issue(s) this PR fixes:

Fixes #173 
