### PR TITLE
Fix Missing .schema Extensions

### DIFF
--- a/schema/enums/TriggerType.schema.json
+++ b/schema/enums/TriggerType.schema.json
@@ -11,5 +11,6 @@
     "ELECTIVE_ON_CONDITION",
     "ELECTIVE_AT_WILL",
     "ELECTIVE_ON_OR_BEFORE_DATE"
-  ]
+  ],
+  "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/TriggerType.schema.json"
 }

--- a/schema/types/vesting/VestingPeriodInDays.schema.json
+++ b/schema/types/vesting/VestingPeriodInDays.schema.json
@@ -17,5 +17,5 @@
     "occurrences": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriod.schema.json"
+  "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInDays.schema.json"
 }

--- a/schema/types/vesting/VestingPeriodInMonths.schema.json
+++ b/schema/types/vesting/VestingPeriodInMonths.schema.json
@@ -22,5 +22,5 @@
   },
   "required": ["day_of_month"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriod.schema.json"
+  "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInMonths.schema.json"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

All OCF **schema** files (not data files) should end in `.schema.json`. Three files (one from the new conversion spec and two from the vesting spec) were missing the `.schema` part of the extension. In validation implementations that were checking for .schema.json, such as a python implementation I am using, this breaks the validation. 

#### Which issue(s) this PR fixes:

No issue opened.
