### PR TITLE
Add additionalProperties: false On All Leaf Nodes

### DIFF
--- a/samples/Manifest.ocf.json
+++ b/samples/Manifest.ocf.json
@@ -27,7 +27,7 @@
       "address_type": "LEGAL",
       "street_suite": "1234 Main Street\nSuite 4",
       "city": "Small Town",
-      "state_province": "DE",
+      "country_subdivision": "DE",
       "country": "US",
       "postal_code": "12345"
     },

--- a/schema/files/StakeholdersFile.schema.json
+++ b/schema/files/StakeholdersFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_STAKEHOLDERS_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StakeholdersFile.schema.json"
 }

--- a/schema/files/StockClassesFile.schema.json
+++ b/schema/files/StockClassesFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_STOCK_CLASSES_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockClassesFile.schema.json"
 }

--- a/schema/files/StockLegendTemplatesFile.schema.json
+++ b/schema/files/StockLegendTemplatesFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_STOCK_LEGEND_TEMPLATES_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockLegendTemplatesFile.schema.json"
 }

--- a/schema/files/StockPlansFile.schema.json
+++ b/schema/files/StockPlansFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_STOCK_PLANS_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockPlansFile.schema.json"
 }

--- a/schema/files/TransactionsFile.schema.json
+++ b/schema/files/TransactionsFile.schema.json
@@ -112,6 +112,7 @@
       "const": "OCF_TRANSACTIONS_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/TransactionsFile.schema.json"
 }

--- a/schema/files/ValuationsFile.schema.json
+++ b/schema/files/ValuationsFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_VALUATIONS_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/ValuationsFile.schema.json"
 }

--- a/schema/files/VestingTermsFile.schema.json
+++ b/schema/files/VestingTermsFile.schema.json
@@ -21,6 +21,7 @@
       "const": "OCF_VESTING_TERMS_FILE"
     }
   },
+  "additionalProperties": false,
   "required": ["items", "file_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/VestingTermsFile.schema.json"
 }

--- a/schema/types/Address.schema.json
+++ b/schema/types/Address.schema.json
@@ -30,6 +30,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "required": ["address_type", "country"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Address.schema.json"
 }

--- a/schema/types/CapitalizationDefinition.schema.json
+++ b/schema/types/CapitalizationDefinition.schema.json
@@ -34,6 +34,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "required": [
     "include_stock_class_ids",
     "include_stock_plans_ids",

--- a/schema/types/ContactInfo.schema.json
+++ b/schema/types/ContactInfo.schema.json
@@ -26,6 +26,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "required": ["name", "phone_numbers", "emails"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ContactInfo.schema.json"
 }

--- a/schema/types/Email.schema.json
+++ b/schema/types/Email.schema.json
@@ -15,6 +15,7 @@
       "format": "email"
     }
   },
+  "additionalProperties": false,
   "required": ["email_type", "email_address"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Email.schema.json"
 }

--- a/schema/types/File.schema.json
+++ b/schema/types/File.schema.json
@@ -14,6 +14,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/types/Md5.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["filepath", "md5"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/File.schema.json"
 }

--- a/schema/types/Monetary.schema.json
+++ b/schema/types/Monetary.schema.json
@@ -14,6 +14,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/types/CurrencyCode.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["amount", "currency"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Monetary.schema.json"
 }

--- a/schema/types/Name.schema.json
+++ b/schema/types/Name.schema.json
@@ -18,6 +18,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "required": ["legal_name"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Name.schema.json"
 }

--- a/schema/types/Phone.schema.json
+++ b/schema/types/Phone.schema.json
@@ -15,6 +15,7 @@
       "pattern": "^\\+\\d{1,3}\\s\\d{2,3}\\s\\d{2,3}\\s\\d{4}$"
     }
   },
+  "additionalProperties": false,
   "required": ["phone_type", "phone_number"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Phone.schema.json"
 }

--- a/schema/types/PreReleaseOmission.schema.json
+++ b/schema/types/PreReleaseOmission.schema.json
@@ -15,6 +15,7 @@
       "type": "boolean"
     }
   },
+  "additionalProperties": false,
   "required": ["omitted"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/PreReleaseOmission.schema.json"
 }

--- a/schema/types/Ratio.schema.json
+++ b/schema/types/Ratio.schema.json
@@ -14,6 +14,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["numerator", "denominator"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Ratio.schema.json"
 }

--- a/schema/types/SecurityExemption.schema.json
+++ b/schema/types/SecurityExemption.schema.json
@@ -14,6 +14,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/types/CountryCode.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["description", "jurisdiction"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/SecurityExemption.schema.json"
 }

--- a/schema/types/StockParent.schema.json
+++ b/schema/types/StockParent.schema.json
@@ -14,6 +14,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "required": ["parent_object_type", "parent_object_id"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/StockParent.schema.json"
 }

--- a/schema/types/TaxID.schema.json
+++ b/schema/types/TaxID.schema.json
@@ -14,6 +14,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/types/CountryCode.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["tax_id", "country"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TaxID.schema.json"
 }

--- a/schema/types/TerminationWindow.schema.json
+++ b/schema/types/TerminationWindow.schema.json
@@ -18,6 +18,7 @@
       "$ref": "https://opencaptablecoalition.com/schema/enums/PeriodType.schema.json"
     }
   },
+  "additionalProperties": false,
   "required": ["reason", "period", "period_type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TerminationWindow.schema.json"
 }

--- a/schema/types/vesting/VestingConditionPortion.schema.json
+++ b/schema/types/vesting/VestingConditionPortion.schema.json
@@ -4,20 +4,22 @@
   "title": "Type - Vesting Condition Portion",
   "description": "Describes a fractional portion (ratio) of shares associated with a Vesting Condition",
   "type": "object",
-  "allOf": [
-    {
-      "$ref": "https://opencaptablecoalition.com/schema/types/Ratio.schema.json"
-    }
-  ],
   "properties": {
-    "numerator": {},
-    "denominator": {},
+    "numerator": {
+      "description": "Numerator of the ratio, i.e. the ratio of A to B (A:B) can be expressed as a fraction (A/B), where A is the numerator",
+      "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
+    },
+    "denominator": {
+      "description": "Denominator of the ratio, i.e. the ratio of A to B (A:B) can be expressed as a fraction (A/B), where B is the denominator",
+      "$ref": "https://opencaptablecoalition.com/schema/types/Numeric.schema.json"
+    },
     "remainder": {
       "description": "If false, the ratio is applied to the entire quantity of the security's issuance. If true, it is applied to the amount that has yet to vest. For example:\n A stakeholder has been granted 1000 shares, and 400 are already vested.\nIf the portion is 1/5 and `remainder` is `false` for a VestingCondition, then that condition will vest 200 shares -- 1/5 of the 1000 granted.\nIf the portion is 1/5 and `remainder` is `true`, then that condition will vest 120 shares -- 1/5 of the 600 unvested.",
       "type": "boolean",
       "default": false
     }
   },
+  "required": ["numerator", "denominator"],
   "additionalProperties": false,
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingConditionPortion.schema.json"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As noted previously, most of our type schemas omitted additionalProperties: false, which was contrary to our design decision to prevent people from adding custom fields in any OCF object or type. 

Added `additionalProperties`: `false` on all leaf nodes. FYI, this required changing how `VestingConditionPortion` was constructed. The ...Portion obj is very similar to Ratio, so it was sensibly constructed by importing all of the Ratio properties with the `allOf` keyword importing the `Ratio` properties. Unfortunately, as a leaf node, `Ratio` can't be used to build another leaf node when `additionalProperties`: `false` is properly added. If we need to construct it this way, I'd suggest creating a base `Ratio` and inheriting that. Since this is only place this pattern was used, however I just duplicated `Ratio` properties in `VestingConditionPortion` as I didn't think it was worth creating the overhead of a primitive `Ratio`.

#### Which issue(s) this PR fixes:

Fixes #188 
