### PR TITLE
Add supplemental doc support

### DIFF
--- a/utils/generate-docs/Schema/Schema.ts
+++ b/utils/generate-docs/Schema/Schema.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "url";
 import SchemaReader from "./SchemaReader.js";
 import SchemaWriter from "./SchemaWriter.js";
 import ExamplesReader from "./ExamplesReader.js";
+import SupplementalsReader from "./SupplementalsReader.js";
+import Supplementals from "./Supplementals.js";
 import Examples, { ExampleJson } from "./Examples.js";
 import TableOfContents from "./TableOfContents.js";
 import SchemaNodeFactory, {
@@ -23,22 +25,32 @@ export default class Schema {
   static generateDocs = async () => {
     const schemaNodeJsons = await SchemaReader.read(path.join(ROOT, "schema"));
     const exampleJsons = await ExamplesReader.read(path.join(ROOT, "samples"));
-    const schema = new Schema(schemaNodeJsons, exampleJsons);
+    const supplementalMarkdowns = await SupplementalsReader.read(
+      path.join(ROOT, "docs", "supplemental")
+    );
+    const schema = new Schema(
+      schemaNodeJsons,
+      exampleJsons,
+      supplementalMarkdowns
+    );
     await SchemaWriter.write(path.join(ROOT), schema);
     await TableOfContents.write(schema, path.join(ROOT, "README.md"));
   };
 
   readonly schemaNodes: SchemaNode[];
   readonly examples: Examples;
+  readonly supplementals: Supplementals;
 
   constructor(
     schemaNodeJsons: SchemaNodeJson[],
-    exampleJsons: ExampleJson[] = []
+    exampleJsons: ExampleJson[] = [],
+    supplementalMarkdowns: string[] = []
   ) {
     this.schemaNodes = schemaNodeJsons.map((json: SchemaNodeJson) =>
       SchemaNodeFactory.build(this, json)
     );
     this.examples = new Examples(exampleJsons);
+    this.supplementals = new Supplementals(supplementalMarkdowns);
   }
 
   findSchemaNodeById = (id: string) => {
@@ -51,6 +63,9 @@ export default class Schema {
 
   findExampleItemsByObjectType = (objectType: string) =>
     this.examples.findExampleItemsByObjectType(objectType);
+
+  findSupplementalMarkdownsByShortId = (shortId: string) =>
+    this.supplementals.findSupplementalMarkdownByShortId(shortId);
 
   filterSchemaNodesByParentType = (parentType: string) =>
     this.schemaNodes.filter(

--- a/utils/generate-docs/Schema/SchemaNode/SchemaNode.ts
+++ b/utils/generate-docs/Schema/SchemaNode/SchemaNode.ts
@@ -68,6 +68,9 @@ export default abstract class SchemaNode {
 
   protected markdownExamples = (): string | null => null;
 
+  protected supplementalMarkdowns = (): string[] =>
+    this.schema.findSupplementalMarkdownsByShortId(this.shortId());
+
   id = () => this.json["$id"];
 
   parentType = () => this.shortId().split("/")[1];
@@ -105,10 +108,18 @@ export default abstract class SchemaNode {
 
 \`${this.id()}\``;
 
-  markdownFooter = () => `**Source Code:** ${this.markdownSourceLink()}
-${this.markdownExamples() ? "\n" + this.markdownExamples() + "\n" : ""}
-Copyright © ${format(new Date(), "Y")} Open Cap Table Coalition.
-`;
+  markdownFooter = () =>
+    [
+      this.supplementalMarkdowns().length > 0
+        ? this.supplementalMarkdowns()
+        : null,
+      `**Source Code:** ${this.markdownSourceLink()}`,
+      this.markdownExamples() ? this.markdownExamples() : null,
+      `Copyright © ${format(new Date(), "Y")} Open Cap Table Coalition.`,
+    ]
+      .flat()
+      .filter(Boolean)
+      .join("\n\n") + "\n";
 
   markdownTableType = () => `\`${this.type().toUpperCase()}\``;
 

--- a/utils/generate-docs/Schema/Supplementals.test.ts
+++ b/utils/generate-docs/Schema/Supplementals.test.ts
@@ -1,0 +1,43 @@
+import Supplementals from "./Supplementals.js";
+
+const RELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE = `
+# This is a test of supplemental documentation
+
+BODY BODY BODY
+
+# See Also:
+
+- [schema/objects/Issuer](/docs/schema/objects/Issuer.md)
+`;
+
+const IRRELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE = `
+# This is a test of supplemental documentation
+
+BODY BODY BODY
+
+# See Also:
+
+- [schema/objects/Stakeholder](/docs/schema/objects/Stakeholder.md)
+`;
+
+describe("Supplementals", () => {
+  describe("#findSupplementalMarkdownsByShortId", () => {
+    it("returns all markdowns that include the shortId string somewhere in the body", () => {
+      const supplementals = new Supplementals([
+        RELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE,
+        IRRELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE,
+      ]);
+
+      const actual = supplementals.findSupplementalMarkdownByShortId(
+        "schema/objects/Issuer"
+      );
+
+      expect(actual).toEqual(
+        expect.arrayContaining([RELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE])
+      );
+      expect(actual).not.toEqual(
+        expect.arrayContaining([IRRELEVANT_SUPPLEMENTAL_MARKDOWN_FIXTURE])
+      );
+    });
+  });
+});

--- a/utils/generate-docs/Schema/Supplementals.ts
+++ b/utils/generate-docs/Schema/Supplementals.ts
@@ -1,0 +1,16 @@
+/**
+ * Represents supplemental markdown documentation and the nodes
+ * to which the documentation applies.
+ */
+export default class Supplementals {
+  protected readonly supplementalMarkdowns: string[];
+
+  constructor(supplementalMarkdowns: string[]) {
+    this.supplementalMarkdowns = supplementalMarkdowns;
+  }
+
+  findSupplementalMarkdownByShortId = (shortId: string) =>
+    this.supplementalMarkdowns.filter((supplementalMarkdown) =>
+      supplementalMarkdown.includes(shortId)
+    );
+}

--- a/utils/generate-docs/Schema/SupplementalsReader.ts
+++ b/utils/generate-docs/Schema/SupplementalsReader.ts
@@ -1,0 +1,33 @@
+import fse from "fs-extra";
+import readdirp, { EntryInfo } from "readdirp";
+
+/**
+ *  Reader loads all supplemental documentation markdown strings into an array.
+ */
+export default class SupplementalsReader {
+  static read = (source: string) => {
+    const reader = new SupplementalsReader(source);
+    return reader.read();
+  };
+
+  readonly source: string;
+
+  constructor(source: string) {
+    this.source = source;
+  }
+
+  protected loadSupplementalMarkdown = (
+    entryInfo: EntryInfo
+  ): Promise<Buffer> => fse.readFile(entryInfo.fullPath);
+
+  protected loadSupplementalMarkdownFromEntryInfos = (
+    entryInfos: EntryInfo[]
+  ): Promise<BufferSource[]> =>
+    Promise.all(entryInfos.map(this.loadSupplementalMarkdown));
+
+  read = (): Promise<string[]> =>
+    readdirp
+      .promise(this.source)
+      .then(this.loadSupplementalMarkdownFromEntryInfos)
+      .then((buffers) => buffers.map((buffer) => buffer.toString()));
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Read the [contributing guidelines](../docs/CONTRIBUTING.md).
2. Ensure you have added or ran the appropriate tests for your PR.
3. If your PR is unfinished, consider creating a [Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Adds the ability to write supplemental markdown documentation files, to be placed in the `docs/supplemental` folder (filename doesn't matter). Any markdown in these files will automatically be included in the documentation of any schema docs whose "shortId" (e.g., `schema/objects/Issuer`) is mentioned in the body of the supplemental doc. We should probably adopt a convention for officially making these mentions, like putting:

```markdown
# See Also:

- [schema/objects/Issuer](/docs/schema/objects/Issuer.md)
```


#### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #228 
