### PR TITLE
Make Our Schema Url Generator Platform Independent (Fix Issue 187)

### DIFF
--- a/utils/schema-utils/EnforceCopyrightNotices.ts
+++ b/utils/schema-utils/EnforceCopyrightNotices.ts
@@ -6,11 +6,13 @@ import core from "@actions/core";
 import yargs, { Arguments } from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import * as path from "path";
+
 import { getSchemaFilepaths } from "./Loaders.js";
 import { schemaUrlFromRepoPath } from "./PathTools.js";
 
 /**
- * Given a schema, with a known local schema_path, generate a
+ * Given a schema, with a known local schema_path, generate an url to the corresponding file in the repo
  * @param schema_path -> Local path where schema_obj was loaded from. WILL BE OVERWRITTEN with serialized data from updated schema_obj.
  * @param schema_inst -> OCF schema JSON to update.
  * @param copyright_year -> Number: What year should copyright notice be for?
@@ -24,6 +26,11 @@ export function addValidOcfCommentToSchema(
   tag: string = "main",
   verbose: boolean = false
 ) {
+  console.log(`addValidOcfCommentToSchema - schema_path: ${schema_path}`);
+  console.log(
+    `addValidOcfCommentToSchema - schema_path ${schema_path.split(path.sep)}`
+  );
+
   let comment_contents = `Copyright © ${copyright_year} Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: ${schemaUrlFromRepoPath(
     schema_path,
     tag
@@ -97,6 +104,9 @@ export async function enforceOcfCopyrightNotices(
         console.log(
           `\t(${index}) Parse JSON Schema at path ${schema_paths[index]}`
         );
+      console.log(
+        `\t(${index}) Parse JSON Schema at path ${schema_paths[index]}`
+      );
       return JSON.parse(schema_buffer.toString()) as Record<string, any>;
     });
 

--- a/utils/schema-utils/EnforceCopyrightNotices.ts
+++ b/utils/schema-utils/EnforceCopyrightNotices.ts
@@ -97,9 +97,6 @@ export async function enforceOcfCopyrightNotices(
         console.log(
           `\t(${index}) Parse JSON Schema at path ${schema_paths[index]}`
         );
-      console.log(
-        `\t(${index}) Parse JSON Schema at path ${schema_paths[index]}`
-      );
       return JSON.parse(schema_buffer.toString()) as Record<string, any>;
     });
 

--- a/utils/schema-utils/EnforceCopyrightNotices.ts
+++ b/utils/schema-utils/EnforceCopyrightNotices.ts
@@ -6,8 +6,6 @@ import core from "@actions/core";
 import yargs, { Arguments } from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import * as path from "path";
-
 import { getSchemaFilepaths } from "./Loaders.js";
 import { schemaUrlFromRepoPath } from "./PathTools.js";
 
@@ -26,11 +24,6 @@ export function addValidOcfCommentToSchema(
   tag: string = "main",
   verbose: boolean = false
 ) {
-  console.log(`addValidOcfCommentToSchema - schema_path: ${schema_path}`);
-  console.log(
-    `addValidOcfCommentToSchema - schema_path ${schema_path.split(path.sep)}`
-  );
-
   let comment_contents = `Copyright © ${copyright_year} Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: ${schemaUrlFromRepoPath(
     schema_path,
     tag

--- a/utils/schema-utils/PathTools.ts
+++ b/utils/schema-utils/PathTools.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+
 import { repo_url_root } from "./Constants.js";
 
 export const schemaDirPath = path.join("__dirname", "../../schema");
@@ -39,7 +40,10 @@ export const basenameFromSchemaPath = (schema_path: string) =>
  * @returns String -> The relative path to the schema file in the ./schema repo dir
  */
 export const schemaPathRelativeToSchemaDir = (schema_path: string) =>
-  `/${path.relative("./schema", schema_path)}`;
+  `/${path.relative("./schema", schema_path)}`.replace(
+    new RegExp("\\" + path.sep, "g"),
+    "/"
+  );
 
 /**
  * Given the local path to the schema, return the schema path relative to the repo root.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

-->

#### What this PR does / why we need it:

As discussed in #187, the utility to generate schema urls was giving us weird output in Windows as it the resulting url had a fix of windows-style backslashes and html forward slash. Used node path library to make the generated url platform independent. 

#### Which issue(s) this PR fixes:

Fixes #187 
