### PR TITLE
Updates title for two classes to reflect actual object

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,13 +709,13 @@ _Used as common building blocks for properties that are more complex than primit
   - **Description:** Describes a period of time expressed in months (e.g. 3 months) for use in Vesting Terms.
   - **View more:** [schema/types/vesting/VestingPeriodInMonths](/docs/schema/types/vesting/VestingPeriodInMonths.md)
 
-- **Type - Vesting Event Trigger**
+- **Type - Vesting Schedule Absolute Trigger**
 
   - **Id:** `https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json`
   - **Description:** Describes a vesting condition satisfied on an absolute date.
   - **View more:** [schema/types/vesting/VestingScheduleAbsoluteTrigger](/docs/schema/types/vesting/VestingScheduleAbsoluteTrigger.md)
 
-- **Type - Vesting Event Trigger**
+- **Type - Vesting Schedule Relative Trigger**
 
   - **Id:** `https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json`
   - **Description:** Describes a vesting condition satisfied when a period of time, relative to another vesting condition, has elapsed.

--- a/docs/schema/types/vesting/VestingScheduleAbsoluteTrigger.md
+++ b/docs/schema/types/vesting/VestingScheduleAbsoluteTrigger.md
@@ -2,7 +2,7 @@
 
 ---
 
-### Type - Vesting Event Trigger
+### Type - Vesting Schedule Absolute Trigger
 
 `https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json`
 

--- a/docs/schema/types/vesting/VestingScheduleRelativeTrigger.md
+++ b/docs/schema/types/vesting/VestingScheduleRelativeTrigger.md
@@ -2,7 +2,7 @@
 
 ---
 
-### Type - Vesting Event Trigger
+### Type - Vesting Schedule Relative Trigger
 
 `https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json`
 

--- a/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json
+++ b/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json",
-  "title": "Type - Vesting Event Trigger",
+  "title": "Type - Vesting Schedule Absolute Trigger",
   "description": "Describes a vesting condition satisfied on an absolute date.",
   "type": "object",
   "allOf": [

--- a/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json
+++ b/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://opencaptablecoalition.com/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json",
-  "title": "Type - Vesting Event Trigger",
+  "title": "Type - Vesting Schedule Relative Trigger",
   "description": "Describes a vesting condition satisfied when a period of time, relative to another vesting condition, has elapsed.",
   "type": "object",
   "allOf": [


### PR DESCRIPTION
Classes updated:
- VestingScheduleAbsoluteTrigger
- VestingScheduleRelativeTrigger

#### What type of PR is this?
/kind cleanup
/kind documentation


#### What this PR does / why we need it:
- The title field in both of the referenced classes is the same as VestingEventTrigger. This is a small quality of life PR where the title is updated to accurately reflect the name of the schema object, for use in logging / debugging. 


#### Which issue(s) this PR fixes:
Fixes #254 
