### PR TITLE
Fixes Windows compatibility for docs generator

### DIFF
--- a/utils/generate-docs/Schema/ExamplesReader.ts
+++ b/utils/generate-docs/Schema/ExamplesReader.ts
@@ -2,6 +2,8 @@ import readdirp, { EntryInfo } from "readdirp";
 
 import { ExampleJson } from "./Examples.js";
 
+import { pathToFileURL } from "url";
+
 /**
  *  Reader parses a file tree of example implementations of JSON data conforming
  * to the OCF and loads into JS objects.
@@ -21,7 +23,7 @@ export default class ExamplesReader {
   protected loadJsonFromEntryInfo = (
     entryInfo: EntryInfo
   ): Promise<ExampleJson> =>
-    import(entryInfo.fullPath).then(
+    import(pathToFileURL(entryInfo.fullPath).href).then(
       (json: { default: ExampleJson }) => json["default"]
     );
 

--- a/utils/generate-docs/Schema/SchemaReader.ts
+++ b/utils/generate-docs/Schema/SchemaReader.ts
@@ -2,6 +2,8 @@ import readdirp, { EntryInfo } from "readdirp";
 
 import { SchemaNodeJson } from "./Schema.js";
 
+import { pathToFileURL } from "url";
+
 /**
  *  Reader parses a file tree of JSON schema files and converts them into
  *  SchemaNode objects.
@@ -21,7 +23,7 @@ export default class SchemaReader {
   protected loadJsonFromEntryInfo = (
     entryInfo: EntryInfo
   ): Promise<SchemaNodeJson> =>
-    import(entryInfo.fullPath).then(
+    import(pathToFileURL(entryInfo.fullPath).href).then(
       (json: { default: SchemaNodeJson }) => json["default"]
     );
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Running `npm run generate-docs` on Windows fails due invalid URL scheme for Windows' files.

#### Which issue(s) this PR fixes:

Fixes #186 
