### PR TITLE
Added scripts to run tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,8 @@
     "prepare": "husky install",
     "validate-ocf-file-schemas": "node ./utils/validate.mjs validate-ocf-schema -v -t",
     "validate-example-ocf-files": "node ./utils/validate.mjs validate-ocf-directory -v -p ./samples -t",
-    "test": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest",
-    "test-windows": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/jest/bin/jest.js",
-    "test:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest --watch",
-    "test-windows:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/jest/bin/jest.js --watch"
+    "test": "node test-script.js",
+    "test:watch": "node test-script.js watch"
   },
   "devDependencies": {
     "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "validate-ocf-file-schemas": "node ./utils/validate.mjs validate-ocf-schema -v -t",
     "validate-example-ocf-files": "node ./utils/validate.mjs validate-ocf-directory -v -p ./samples -t",
     "test": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest",
-    "test:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest --watch"
+    "test-windows": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/jest/bin/jest.js",
+    "test:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest --watch",
+    "test-windows:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/jest/bin/jest.js --watch"
   },
   "devDependencies": {
     "@actions/core": "^1.6.0",

--- a/test-script.js
+++ b/test-script.js
@@ -1,0 +1,19 @@
+import { spawn } from "child_process";
+
+var args = [
+  "--experimental-vm-modules",
+  "--experimental-json-modules",
+  "--no-warnings",
+];
+
+args.push(
+  process.platform === "win32"
+    ? "node_modules/jest/bin/jest.js"
+    : "node_modules/.bin/jest"
+);
+
+if (process.argv[2] && process.argv[2] === "watch") {
+  args.push("--watch");
+}
+
+spawn("node", args, { stdio: "inherit" });


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Running `npm run test` should work on Windows.

#### Which issue(s) this PR fixes:

Fixes #292 

#### See
https://jestjs.io/docs/troubleshooting
https://github.com/facebook/jest/issues/3750
