### PR TITLE
Added `conversion_price` field to RatioConversionMechanism.schema.json

### DIFF
--- a/docs/schema/objects/StockClass.md
+++ b/docs/schema/objects/StockClass.md
@@ -77,6 +77,10 @@
       {
         "conversion_mechanism": {
           "type": "RATIO_CONVERSION",
+          "conversion_price": {
+            "amount": "1.00",
+            "currency": "USD"
+          },
           "ratio": {
             "numerator": "1",
             "denominator": "1"

--- a/docs/schema/types/conversion_mechanisms/RatioConversionMechanism.md
+++ b/docs/schema/types/conversion_mechanisms/RatioConversionMechanism.md
@@ -12,11 +12,12 @@ _Sets forth inputs and conversion mechanism of a ratio conversion (primarily use
 
 **Properties:**
 
-| Property      | Type                                                                                                                                                       | Description                                                                     | Required   |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------- |
-| type          | **Constant:** `RATIO_CONVERSION`                                                                                                                           | Scalar Constant                                                                 | `REQUIRED` |
-| ratio         | [schema/types/Ratio](/docs/schema/types/Ratio.md)                                                                                                          | One share of this stock class converts into this many target stock class shares | `REQUIRED` |
-| rounding_type | `Enum - Rounding Type`</br></br>_Description:_ Enumeration of rounding types</br></br>**ONE OF:** </br>&bull; CEILING </br>&bull; FLOOR </br>&bull; NORMAL | How should fractional shares be rounded?                                        | `REQUIRED` |
+| Property         | Type                                                                                                                                                       | Description                                                                     | Required   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------- |
+| type             | **Constant:** `RATIO_CONVERSION`                                                                                                                           | Scalar Constant                                                                 | `REQUIRED` |
+| conversion_price | [schema/types/Monetary](/docs/schema/types/Monetary.md)                                                                                                    | What is the effective conversion price per share of this stock class?           | `REQUIRED` |
+| ratio            | [schema/types/Ratio](/docs/schema/types/Ratio.md)                                                                                                          | One share of this stock class converts into this many target stock class shares | `REQUIRED` |
+| rounding_type    | `Enum - Rounding Type`</br></br>_Description:_ Enumeration of rounding types</br></br>**ONE OF:** </br>&bull; CEILING </br>&bull; FLOOR </br>&bull; NORMAL | How should fractional shares be rounded?                                        | `REQUIRED` |
 
 **Source Code:** [schema/types/conversion_mechanisms/RatioConversionMechanism](/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json)
 

--- a/samples/StockClasses.ocf.json
+++ b/samples/StockClasses.ocf.json
@@ -38,6 +38,10 @@
         {
           "conversion_mechanism": {
             "type": "RATIO_CONVERSION",
+            "conversion_price": {
+              "amount": "1.00",
+              "currency": "USD"
+            },
             "ratio": {
               "numerator": "1",
               "denominator": "1"

--- a/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json
@@ -13,6 +13,10 @@
     "type": {
       "const": "RATIO_CONVERSION"
     },
+    "conversion_price": {
+      "description": "What is the effective conversion price per share of this stock class?",
+      "$ref": "https://opencaptablecoalition.com/schema/types/Monetary.schema.json"
+    },
     "ratio": {
       "description": "One share of this stock class converts into this many target stock class shares",
       "$ref": "https://opencaptablecoalition.com/schema/types/Ratio.schema.json"
@@ -23,6 +27,6 @@
     }
   },
   "additionalProperties": false,
-  "required": ["ratio", "rounding_type", "type"],
+  "required": ["ratio", "conversion_price", "rounding_type", "type"],
   "$comment": "Copyright © 2022 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

As part of changes to track changes in conversion ratio / conversion_price of stock classes, we decided to made conversion_price a field of the RatioConversionMechanism. Then, the Conversion Ratio Adjustment proposed in #302 can just contain a new RatioConversionMechanism, rather than a `conversion_price` field and a separate `RatioConversionMechanism` type. 

#### Which issue(s) this PR fixes:

Fixes #305 