### PR TITLE
Set npm to ~8.19 in package engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5",
         "yargs": "^17.3.1"
+      },
+      "engines": {
+        "npm": "~8.19"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "dependencies": {
     "date-fns": "^2.28.0"
+  },
+  "engines": {
+    "npm": "~8.19"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Read the [contributing guidelines](../docs/CONTRIBUTING.md).
2. Ensure you have added or ran the appropriate tests for your PR.
3. If your PR is unfinished, consider creating a [Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
-->

#### What type of PR is this?
Developer experience

<!--
Add one of the following kinds:

/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:
Establishing the acceptable `npm` version in the `engines` block of the package file will ensure developers are using the same version of `npm`, avoiding unexpected changes or thrashing of the lockfile.

#### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A, follow-up from 2022-11-08 TWG call.
