### PR TITLE
Changed Jurisdiction Field in SecurityExemption to a Plain String

### DIFF
--- a/docs/schema_markdown/schema/types/SecurityExemption.md
+++ b/docs/schema_markdown/schema/types/SecurityExemption.md
@@ -12,10 +12,10 @@ _Type representation of a securities issuance exemption that includes an unstruc
 
 **Properties:**
 
-| Property     | Type                                        | Description                                                                 | Required   |
-| ------------ | ------------------------------------------- | --------------------------------------------------------------------------- | ---------- |
-| description  | `STRING`                                    | Description of an applicable security law exemption governing the issuance  | `REQUIRED` |
-| jurisdiction | [schema/types/CountryCode](/CountryCode.md) | Country code of the jurisdiction of the applicable law (ISO 3166-1 alpha-2) | `REQUIRED` |
+| Property     | Type     | Description                                                                                                                                                                                                                                                         | Required   |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| description  | `STRING` | Description of an applicable security law exemption governing the issuance                                                                                                                                                                                          | `REQUIRED` |
+| jurisdiction | `STRING` | Jurisdiction of the applicable law. This is a free-text field as there is no known enumeration of all global legal jurisdictions, but please try to use ISO 3166-1 alpha-2, if appropriate. Otherwise, we rely on implementers to choose an appropriate value here. | `REQUIRED` |
 
 **Source Code:** [schema/types/SecurityExemption](../../../../schema/types/SecurityExemption.schema.json)
 

--- a/schema/types/SecurityExemption.schema.json
+++ b/schema/types/SecurityExemption.schema.json
@@ -10,8 +10,8 @@
       "type": "string"
     },
     "jurisdiction": {
-      "description": "Country code of the jurisdiction of the applicable law (ISO 3166-1 alpha-2)",
-      "$ref": "https://opencaptablecoalition.com/schema/types/CountryCode.schema.json"
+      "description": "Jurisdiction of the applicable law. This is a free-text field as there is no known enumeration of all global legal jurisdictions, but please try to use ISO 3166-1 alpha-2, if appropriate. Otherwise, we rely on implementers to choose an appropriate value here.",
+      "type": "string"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As discussed in issue #315, we realized that ISO 3166-1 alpha2 does not cleanly represent real legal jurisdictions, particularly outside of the U.S. Since there is no known enumeration of valid legal jurisdictions, we are moving this to free text. I left in the description that implementers should to try to use ISO 3166-1 alpha2 where appropriate but otherwise we rely on implementers to choose an appropriate value / convention. 

I wasn't 100% sure whether to change `country_subdivision_of_formation` field on `Issuer` to free text. I believe we agreed **not** to, but @jacobyavis, @pjohnmeyer, is that what you remember as well?

#### Which issue(s) this PR fixes:

Fixes #315
