### PR TITLE
Avoid running the publish workflow on new PRs 

### DIFF
--- a/.github/workflows/generate-and-publish-mkdocs.yml
+++ b/.github/workflows/generate-and-publish-mkdocs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   create-mkdocs-docs:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup 

#### What this PR does / why we need it:

This ensures that PRs do not run the generate-and-publish-mkdocs action. Those actions would have failed anyway on PRs from non-contributors (See #343). 

You can verify this worked because the `generate-and-publish` actions should not run in this PR

#### Which issue(s) this PR fixes:

Fixes #333 
