### PR TITLE
Add Mermaid Rendering to MkDocs

### DIFF
--- a/docs/schema_markdown/schema/objects/Valuation.md
+++ b/docs/schema_markdown/schema/objects/Valuation.md
@@ -45,7 +45,9 @@
     "effective_date": "2022-01-28",
     "valuation_type": "409A",
     "stock_class_id": "8d8371e8-d41d-4a49-9f42-b91758fd155d",
-    "comments": ["Wow, what a great deal this guy gave us."]
+    "comments": [
+      "Wow, what a great deal this guy gave us."
+    ]
   }
 ]
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,11 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Our MkDocs setup can render [Mermaid.js](https://mermaid.js.org/#/) diagrams, but we need a [plugin to do it](https://squidfunk.github.io/mkdocs-material/reference/diagrams/). This PR enables the plugin and should render Mermaid diagrams nicely inline in our MkDocs pages.

#### Which issue(s) this PR fixes:

No PR opened.
