### PR TITLE
Suggested refractor for easier code generation

### DIFF
--- a/schema/primitives/types/conversion_rights/ConversionRight.schema.json
+++ b/schema/primitives/types/conversion_rights/ConversionRight.schema.json
@@ -11,26 +11,7 @@
     },
     "conversion_mechanism": {
       "description": "What conversion mechanism applies to calculate the number of resulting securities?",
-      "oneOf": [
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json"
-        }
-      ]
+      "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json"
     },
     "converts_to_future_round": {
       "description": "Is this stock class potentially convertible into a future, as-yet undetermined stock class (e.g. Founder Preferred)",

--- a/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json
+++ b/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json
@@ -23,17 +23,7 @@
     },
     "conversion_right": {
       "description": "When the conditions of the trigger are met, how does the convertible convert?",
-      "oneOf": [
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
-        }
-      ]
+      "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/primitives/types/conversion_rights/ConversionRight.schema.json"
     }
   },
   "required": ["type", "trigger_id", "conversion_right"],

--- a/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json
+++ b/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json
@@ -20,7 +20,20 @@
     "type": {
       "const": "AUTOMATIC_ON_CONDITION"
     },
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_condition", "type", "conversion_right"],

--- a/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json
+++ b/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json
@@ -20,7 +20,20 @@
     "type": {
       "const": "AUTOMATIC_ON_DATE"
     },
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_date", "type", "conversion_right"],

--- a/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json
@@ -16,7 +16,20 @@
     "type": {
       "const": "ELECTIVE_AT_WILL"
     },
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": ["trigger_id", "type", "conversion_right"],

--- a/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json
@@ -24,7 +24,20 @@
     },
     "nickname": {},
     "trigger_description": {},
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": [

--- a/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json
@@ -20,7 +20,20 @@
     "type": {
       "const": "ELECTIVE_ON_CONDITION"
     },
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_condition", "type", "conversion_right"],

--- a/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json
+++ b/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json
@@ -16,7 +16,20 @@
     "type": {
       "const": "UNSPECIFIED"
     },
-    "conversion_right": {}
+    "conversion_right": {
+      "description": "When the conditions of the trigger are met, how does the convertible convert?",
+      "oneOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+        }
+      ]
+    }
   },
   "additionalProperties": false,
   "required": ["trigger_id", "type", "conversion_right"],


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When generating Python code from the schema, I encountered a problem. Several types reference primitives to implement those schemas. In Python, using the primitives as a baseclass has several benefits. For example you can check if something is a ConversionMechanism by doing `isinstance(object, ConversionMechanism)` with no need to list all possible types of conversion mechanisms.

However, the primitive types reference instantiatable types, and this causes circular imports in Python. Basically when a type using a ConversionMechanism gets loaded this leads to loading of the primitive, that leads to loading the other primitives, which tries to load the instantiable types, one of is currently being loaded, and therefore it fails.

By referencing only primitive types from primitives we avoid these circular imports.

There are various other ways of avoiding this (at least in Python, and this may very well be a Python only problem), but they all result in "ugly" code, one way or another, so this is not a deal breaker. But this is my preferred solution.

#### Which issue(s) this PR fixes:

Avoids circular imports in Python in a nice way.
