### PR TITLE
Validate obj against obj_type schema

### DIFF
--- a/utils/validate.mjs
+++ b/utils/validate.mjs
@@ -53,20 +53,16 @@ export const URI_LOOKUP_FOR_FILE_TYPE = {
 async function buildObjectSchemaMap(verbose = false) {
   const schemaMap = {};
 
-  if (verbose) console.log("\n-->\tLoad Schema Files...\n");
   const schemaPaths = await getSchemaObjectsFilepaths();
 
-  if (verbose) console.log("\n-->\tParse Schema Objs...");
   const schema_buffers = await Promise.all(
     schemaPaths.map((path) => readFile(path))
   );
 
-  if (verbose) console.log("\n-->\tParsing Schema JSONs");
   const schemas = schema_buffers.map((schema_buffer) => {
     return JSON.parse(schema_buffer.toString());
   });
 
-  if (verbose) console.log("\n-->\tBuilding Schema Map");
   schemas.forEach((schema) => {
     schemaMap[schema.properties.object_type.const] = schema.$id;
   });
@@ -204,14 +200,15 @@ export async function validateOcfDirectory(
         // if file is not a manifest, loop through items
         // for each item, get the object_type and then run the validator against that schema
       } else if (obj.hasOwnProperty("items")) {
+        if (verbose) console.log("\n-->\tvalidating items:");
+
         const objectTypeToSchemaIdMap = await buildObjectSchemaMap(verbose);
         for (let j = 0; j < obj.items.length; j++) {
           let object_type = obj.items[j].object_type;
           let object_schema_uri = objectTypeToSchemaIdMap[object_type];
 
           if (verbose) {
-            console.log("item being validated:");
-            console.log(obj.items[j]);
+            console.dir(obj.items[j], { depth: null, colors: true });
           }
 
           const validator = ajv.getSchema(object_schema_uri);
@@ -231,8 +228,6 @@ export async function validateOcfDirectory(
               console.log(validator.errors);
             }
             return false;
-          } else {
-            if (verbose) console.log("\n\t** VALID OCF **");
           }
         }
       }


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
In the current state, the validator behaves like this:
- It ingests every file in a given directory, and compares it to the corresponding file schema
- each file object has an `items` array (with the exception of the manifest file), and in the case of the transactions file, each `item` can be `"oneOf"` many different kinds of schemas.
- the validator will attempt to validate the item being processed against every schema in it's `"oneOf"` list and record the errors for all the schemas.

**Result:** all of the validation errors are shown, instead of the one that is most pertinent to the user. 

#### This PR changes the validator's behavior in the following way:
- Adds a few helper functions that map each schema's `object_type` => `const` value to the schema's `$id`. This is referred to as the `objectSchemaMap`
- when the validator loops through every item in the `items` array:
       - grabs that item's corresponding schema `$id` with the `objectSchemaMap`
       - Grabs the schema associated with the $id from the [ajv instance cache](https://ajv.js.org/guide/managing-schemas.html#using-ajv-instance-cache)
       - Validates the item against the matched schema 

#### Which issue(s) this PR fixes:
Fixes #388


#### TODO:
- [ ] fix the if / else logic so that file level validation occurs on all files as well as the object specific validation 
- [ ] refactor the code