### PR TITLE
bumps PyYaml to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Pygments==2.13.0
 pymdown-extensions==9.6
 pyparsing==3.0.9
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml-env-tag==0.1
 requests==2.28.1
 six==1.16.0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This bumps the PyYaml dependency to 6.0.1 because I was running into https://github.com/yaml/pyyaml/issues/724 during setup. Looks like it's a bit of a known issue and folks are getting around it via this bump.