### PR TITLE
adds some context around the review cadence for PRs in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 1. Read the [contributing guidelines](../docs/CONTRIBUTING.md).
 2. Ensure you have added or ran the appropriate tests for your PR.
 3. If your PR is unfinished, consider creating a [Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
-4. PRs are discussed, reviewed, and responded to on a bi-weekly basis by the Technical Working Group. We'll get back to you soon!
+4. PRs are discussed, reviewed, and responded to every two weeks by the Technical Working Group. We'll get back to you soon!
 -->
 
 #### What type of PR is this?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 1. Read the [contributing guidelines](../docs/CONTRIBUTING.md).
 2. Ensure you have added or ran the appropriate tests for your PR.
 3. If your PR is unfinished, consider creating a [Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
+4. PRs are discussed, reviewed, and responded to on a bi-weekly basis by the Technical Working Group. We'll get back to you soon!
 -->
 
 #### What type of PR is this?


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

/kind documentation

#### What this PR does / why we need it:

Educates on how and sets some expectations for when a user will receive feedback on a PR. Feel like this will be a good first step before graduating to auto responders/bots.

I might be missed the mark on the messaging though? @JSv4 to approve/rephrase.