### PR TITLE
Mkdocs Publish Only on Release or Manual Trigger

### DIFF
--- a/.github/workflows/generate-and-publish-mkdocs.yml
+++ b/.github/workflows/generate-and-publish-mkdocs.yml
@@ -1,9 +1,9 @@
 name: Publish Docs
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
+  workflow_dispatch:
 
 jobs:
   create-mkdocs-docs:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

We want to stop doc drift and only have docs publish on release. Eventually, we want to version the docs by release. ATM, the doc site will be updated with whatever is in main on release. We may need to do additional work here with $id updates. 

Changed our action to run when new stable release is published. See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release for full list of possible release events to subscribe to. 

This will still ultimately release what's in main, so if our release process puts all release schema $ids in a release branch, this won't publish the precise release schemas and $ids, so we may need to make further changes. This is happening anyway, however, so this PR will still improve the current situation. 

Possibly we make the release process a Github action. These can be triggered manually via Github UI if you add a `  workflow_dispatch:` trigger. We could do both the final schema updates - changing ids to release ids - and the mk docs publication from the same action.

#### Which issue(s) this PR fixes:

Fixes #510 

