### PR TITLE
Fix "Compatibility Wrapper" object docs written to wrong part of tree

### DIFF
--- a/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.ts
+++ b/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.ts
@@ -2,7 +2,6 @@ import { format } from "date-fns";
 import path from "node:path";
 import { relativePathToOtherPath } from "../../../schema-utils/PathTools.js";
 
-import { repo_raw_url_root } from "../../../schema-utils/Constants.js";
 import Schema from "../Schema.js";
 import { PropertyJson } from "./Property/Factory.js";
 import SchemaNode from "./SchemaNode.js";
@@ -40,9 +39,6 @@ export default class BackwardsCompatibleObjectSchemaNode extends SchemaNode {
   type = () => this.schema.findSchemaNodeById(this.replacementSchemaId).type();
 
   protected basename = () => path.basename(this.id(), ".schema.json");
-
-  protected directory = () =>
-    path.dirname(this.id().slice(`${repo_raw_url_root}/main/`.length));
 
   protected allOf = (): SchemaNode[] => [];
 

--- a/utils/generate-docs/Schema/SchemaNode/Factory.ts
+++ b/utils/generate-docs/Schema/SchemaNode/Factory.ts
@@ -13,7 +13,6 @@ import TypePatternSchemaNode, {
   TypePatternSchemaNodeJson,
 } from "./TypePattern.js";
 export { default as SchemaNode } from "./SchemaNode.js";
-import { repo_raw_url_root } from "../../../schema-utils/Constants.js";
 import BackwardsCompatibleSchemaNode, {
   BackwardsCompatibleObjectSchemaNodeJson,
 } from "./BackwardsCompatibleObjectSchemaNode.js";


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As flagged in #430, doc generator is writing "Compatibility Wrapper" object docs written to wrong part of tree.

It appears the cause of the issue was improper overriding of `SchemaNode` `.directory()` function in `BackwardsCompatibleObjectSchemaNode.ts`, but I am running into an issue getting test suite to run under Windows (see issue #517) and am going to run the action here to check there are no other ill-effects. 

#### Which issue(s) this PR fixes:

Fixes #430
