### PR TITLE
Add IssuerAuthorizedSharesAdjustment to the list of transaction classes

### DIFF
--- a/schema/files/TransactionsFile.schema.json
+++ b/schema/files/TransactionsFile.schema.json
@@ -122,6 +122,9 @@
           },
           {
             "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.schema.json"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json"
           }
         ]
       }


### PR DESCRIPTION
Add IssuerAuthorizedSharesAdjustment to the list of transaction classes in TransactionFile

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PyOCF fails schema validation if you add a IssuerAuthorizedSharesAdjustment to the items in a TransactionFile.
PyOCF v1.2.0b1 uses a fork of this schema with the same change, and then it works.

#### Which issue(s) this PR fixes:

I didn't file a separate issue, as this change is so small that we can discuss it on the PR. 