### PR TITLE
Upgrade Setup-Node Version in GitHub Action Workflows

### DIFF
--- a/.github/workflows/check-example-ocf-files.yml
+++ b/.github/workflows/check-example-ocf-files.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/check-gen-docs.yml
+++ b/.github/workflows/check-gen-docs.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/check-ocf-schema-file-copyright-notices.yml
+++ b/.github/workflows/check-ocf-schema-file-copyright-notices.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/check-schema-files.yml
+++ b/.github/workflows/check-schema-files.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/generate-and-publish-mkdocs.yml
+++ b/.github/workflows/generate-and-publish-mkdocs.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v6
         with:
           cache: "npm"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

All GitHub actions are failing on node setup step. This appears to be related to deprecated env variable handling resulting in setup action failing to access cache. I believe upgrading to v6 will address this.

#### Which issue(s) this PR fixes:

Fixes #549 
