### PR TITLE
Fix NPM security vulnerabilities (handlebars, lodash, minimatch, picomatch, @babel/runtime, js-yaml)

### DIFF
--- a/docs/schema_markdown/schema/enums/AccrualPeriodType.md
+++ b/docs/schema_markdown/schema/enums/AccrualPeriodType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/AccrualPeriodType](../../../../schema/enums/AccrualPeriodType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/AddressType.md
+++ b/docs/schema_markdown/schema/enums/AddressType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/AddressType](../../../../schema/enums/AddressType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/AllocationType.md
+++ b/docs/schema_markdown/schema/enums/AllocationType.md
@@ -15,4 +15,4 @@
 
 **Source Code:** [schema/enums/AllocationType](../../../../schema/enums/AllocationType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/AuthorizedShares.md
+++ b/docs/schema_markdown/schema/enums/AuthorizedShares.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/AuthorizedShares](../../../../schema/enums/AuthorizedShares.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/CompensationType.md
+++ b/docs/schema_markdown/schema/enums/CompensationType.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/enums/CompensationType](../../../../schema/enums/CompensationType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/CompoundingType.md
+++ b/docs/schema_markdown/schema/enums/CompoundingType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/CompoundingType](../../../../schema/enums/CompoundingType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ConversionMechanismType.md
+++ b/docs/schema_markdown/schema/enums/ConversionMechanismType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ConversionMechanismType](../../../../schema/enums/ConversionMechanismType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ConversionRightType.md
+++ b/docs/schema_markdown/schema/enums/ConversionRightType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ConversionRightType](../../../../schema/enums/ConversionRightType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ConversionTimingType.md
+++ b/docs/schema_markdown/schema/enums/ConversionTimingType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ConversionTimingType](../../../../schema/enums/ConversionTimingType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ConversionTriggerType.md
+++ b/docs/schema_markdown/schema/enums/ConversionTriggerType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ConversionTriggerType](../../../../schema/enums/ConversionTriggerType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ConvertibleType.md
+++ b/docs/schema_markdown/schema/enums/ConvertibleType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ConvertibleType](../../../../schema/enums/ConvertibleType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/DayCountType.md
+++ b/docs/schema_markdown/schema/enums/DayCountType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/DayCountType](../../../../schema/enums/DayCountType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/EmailType.md
+++ b/docs/schema_markdown/schema/enums/EmailType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/EmailType](../../../../schema/enums/EmailType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/FileType.md
+++ b/docs/schema_markdown/schema/enums/FileType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/FileType](../../../../schema/enums/FileType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/InterestPayoutType.md
+++ b/docs/schema_markdown/schema/enums/InterestPayoutType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/InterestPayoutType](../../../../schema/enums/InterestPayoutType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ObjectType.md
+++ b/docs/schema_markdown/schema/enums/ObjectType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ObjectType](../../../../schema/enums/ObjectType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/OptionType.md
+++ b/docs/schema_markdown/schema/enums/OptionType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/OptionType](../../../../schema/enums/OptionType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ParentSecurityType.md
+++ b/docs/schema_markdown/schema/enums/ParentSecurityType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ParentSecurityType](../../../../schema/enums/ParentSecurityType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/PeriodType.md
+++ b/docs/schema_markdown/schema/enums/PeriodType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/PeriodType](../../../../schema/enums/PeriodType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/PhoneType.md
+++ b/docs/schema_markdown/schema/enums/PhoneType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/PhoneType](../../../../schema/enums/PhoneType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/QuantitySourceType.md
+++ b/docs/schema_markdown/schema/enums/QuantitySourceType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/QuantitySourceType](../../../../schema/enums/QuantitySourceType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/RoundingType.md
+++ b/docs/schema_markdown/schema/enums/RoundingType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/RoundingType](../../../../schema/enums/RoundingType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StakeholderRelationshipType.md
+++ b/docs/schema_markdown/schema/enums/StakeholderRelationshipType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StakeholderRelationshipType](../../../../schema/enums/StakeholderRelationshipType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StakeholderStatusType.md
+++ b/docs/schema_markdown/schema/enums/StakeholderStatusType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StakeholderStatusType](../../../../schema/enums/StakeholderStatusType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StakeholderType.md
+++ b/docs/schema_markdown/schema/enums/StakeholderType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StakeholderType](../../../../schema/enums/StakeholderType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StockClassType.md
+++ b/docs/schema_markdown/schema/enums/StockClassType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StockClassType](../../../../schema/enums/StockClassType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StockIssuanceType.md
+++ b/docs/schema_markdown/schema/enums/StockIssuanceType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StockIssuanceType](../../../../schema/enums/StockIssuanceType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/StockPlanCancellationBehaviorType.md
+++ b/docs/schema_markdown/schema/enums/StockPlanCancellationBehaviorType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/StockPlanCancellationBehaviorType](../../../../schema/enums/StockPlanCancellationBehaviorType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/TerminationWindowType.md
+++ b/docs/schema_markdown/schema/enums/TerminationWindowType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/TerminationWindowType](../../../../schema/enums/TerminationWindowType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ValuationBasedFormulaType.md
+++ b/docs/schema_markdown/schema/enums/ValuationBasedFormulaType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ValuationBasedFormulaType](../../../../schema/enums/ValuationBasedFormulaType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/ValuationType.md
+++ b/docs/schema_markdown/schema/enums/ValuationType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/ValuationType](../../../../schema/enums/ValuationType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/VestingDayOfMonth.md
+++ b/docs/schema_markdown/schema/enums/VestingDayOfMonth.md
@@ -11,4 +11,4 @@
 
 **Source Code:** [schema/enums/VestingDayOfMonth](../../../../schema/enums/VestingDayOfMonth.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/enums/VestingTriggerType.md
+++ b/docs/schema_markdown/schema/enums/VestingTriggerType.md
@@ -8,4 +8,4 @@
 
 **Source Code:** [schema/enums/VestingTriggerType](../../../../schema/enums/VestingTriggerType.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/DocumentsFile.md
+++ b/docs/schema_markdown/schema/files/DocumentsFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/DocumentsFile](../../../../schema/files/DocumentsFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/FinancingsFile.md
+++ b/docs/schema_markdown/schema/files/FinancingsFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/FinancingsFile](../../../../schema/files/FinancingsFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/OCFManifestFile.md
+++ b/docs/schema_markdown/schema/files/OCFManifestFile.md
@@ -32,4 +32,4 @@
 
 **Source Code:** [schema/files/OCFManifestFile](../../../../schema/files/OCFManifestFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/StakeholdersFile.md
+++ b/docs/schema_markdown/schema/files/StakeholdersFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/StakeholdersFile](../../../../schema/files/StakeholdersFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/StockClassesFile.md
+++ b/docs/schema_markdown/schema/files/StockClassesFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/StockClassesFile](../../../../schema/files/StockClassesFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/StockLegendTemplatesFile.md
+++ b/docs/schema_markdown/schema/files/StockLegendTemplatesFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/StockLegendTemplatesFile](../../../../schema/files/StockLegendTemplatesFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/StockPlansFile.md
+++ b/docs/schema_markdown/schema/files/StockPlansFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/StockPlansFile](../../../../schema/files/StockPlansFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/TransactionsFile.md
+++ b/docs/schema_markdown/schema/files/TransactionsFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/TransactionsFile](../../../../schema/files/TransactionsFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/ValuationsFile.md
+++ b/docs/schema_markdown/schema/files/ValuationsFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/ValuationsFile](../../../../schema/files/ValuationsFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/files/VestingTermsFile.md
+++ b/docs/schema_markdown/schema/files/VestingTermsFile.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/files/VestingTermsFile](../../../../schema/files/VestingTermsFile.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/Document.md
+++ b/docs/schema_markdown/schema/objects/Document.md
@@ -63,4 +63,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/Financing.md
+++ b/docs/schema_markdown/schema/objects/Financing.md
@@ -42,4 +42,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/Issuer.md
+++ b/docs/schema_markdown/schema/objects/Issuer.md
@@ -31,4 +31,4 @@
 
 **Source Code:** [schema/objects/Issuer](../../../../schema/objects/Issuer.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/Stakeholder.md
+++ b/docs/schema_markdown/schema/objects/Stakeholder.md
@@ -186,4 +186,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/StockClass.md
+++ b/docs/schema_markdown/schema/objects/StockClass.md
@@ -94,4 +94,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/StockLegendTemplate.md
+++ b/docs/schema_markdown/schema/objects/StockLegendTemplate.md
@@ -35,4 +35,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/StockPlan.md
+++ b/docs/schema_markdown/schema/objects/StockPlan.md
@@ -48,4 +48,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/Valuation.md
+++ b/docs/schema_markdown/schema/objects/Valuation.md
@@ -49,4 +49,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/VestingTerms.md
+++ b/docs/schema_markdown/schema/objects/VestingTerms.md
@@ -516,4 +516,4 @@ For a more thorough explanation, see [Vesting Terms Explained](../../explainers/
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/acceptance/ConvertibleAcceptance.md
+++ b/docs/schema_markdown/schema/objects/transactions/acceptance/ConvertibleAcceptance.md
@@ -49,4 +49,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/acceptance/EquityCompensationAcceptance.md
+++ b/docs/schema_markdown/schema/objects/transactions/acceptance/EquityCompensationAcceptance.md
@@ -49,4 +49,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/acceptance/PlanSecurityAcceptance.md
+++ b/docs/schema_markdown/schema/objects/transactions/acceptance/PlanSecurityAcceptance.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/acceptance/PlanSecurityAcceptance](../../../../../../schema/objects/transactions/acceptance/PlanSecurityAcceptance.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/acceptance/StockAcceptance.md
+++ b/docs/schema_markdown/schema/objects/transactions/acceptance/StockAcceptance.md
@@ -48,4 +48,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/acceptance/WarrantAcceptance.md
+++ b/docs/schema_markdown/schema/objects/transactions/acceptance/WarrantAcceptance.md
@@ -48,4 +48,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.md
+++ b/docs/schema_markdown/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.md
@@ -55,4 +55,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.md
+++ b/docs/schema_markdown/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.md
@@ -45,4 +45,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.md
+++ b/docs/schema_markdown/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.md
@@ -53,4 +53,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.md
+++ b/docs/schema_markdown/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.md
@@ -46,4 +46,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/cancellation/ConvertibleCancellation.md
+++ b/docs/schema_markdown/schema/objects/transactions/cancellation/ConvertibleCancellation.md
@@ -63,4 +63,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/cancellation/EquityCompensationCancellation.md
+++ b/docs/schema_markdown/schema/objects/transactions/cancellation/EquityCompensationCancellation.md
@@ -57,4 +57,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/cancellation/PlanSecurityCancellation.md
+++ b/docs/schema_markdown/schema/objects/transactions/cancellation/PlanSecurityCancellation.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/cancellation/PlanSecurityCancellation](../../../../../../schema/objects/transactions/cancellation/PlanSecurityCancellation.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/cancellation/StockCancellation.md
+++ b/docs/schema_markdown/schema/objects/transactions/cancellation/StockCancellation.md
@@ -56,4 +56,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/cancellation/WarrantCancellation.md
+++ b/docs/schema_markdown/schema/objects/transactions/cancellation/WarrantCancellation.md
@@ -56,4 +56,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.md
+++ b/docs/schema_markdown/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.md
@@ -67,4 +67,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.md
+++ b/docs/schema_markdown/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.md
@@ -43,4 +43,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/consolidation/StockConsolidation.md
+++ b/docs/schema_markdown/schema/objects/transactions/consolidation/StockConsolidation.md
@@ -44,4 +44,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/conversion/ConvertibleConversion.md
+++ b/docs/schema_markdown/schema/objects/transactions/conversion/ConvertibleConversion.md
@@ -100,4 +100,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/conversion/StockConversion.md
+++ b/docs/schema_markdown/schema/objects/transactions/conversion/StockConversion.md
@@ -62,4 +62,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/exercise/EquityCompensationExercise.md
+++ b/docs/schema_markdown/schema/objects/transactions/exercise/EquityCompensationExercise.md
@@ -63,4 +63,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/exercise/PlanSecurityExercise.md
+++ b/docs/schema_markdown/schema/objects/transactions/exercise/PlanSecurityExercise.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/exercise/PlanSecurityExercise](../../../../../../schema/objects/transactions/exercise/PlanSecurityExercise.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/exercise/WarrantExercise.md
+++ b/docs/schema_markdown/schema/objects/transactions/exercise/WarrantExercise.md
@@ -62,4 +62,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/issuance/ConvertibleIssuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/issuance/ConvertibleIssuance.md
@@ -236,4 +236,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/issuance/EquityCompensationIssuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/issuance/EquityCompensationIssuance.md
@@ -288,4 +288,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/issuance/PlanSecurityIssuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/issuance/PlanSecurityIssuance.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/issuance/PlanSecurityIssuance](../../../../../../schema/objects/transactions/issuance/PlanSecurityIssuance.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/issuance/StockIssuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/issuance/StockIssuance.md
@@ -311,4 +311,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/issuance/WarrantIssuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/issuance/WarrantIssuance.md
@@ -286,4 +286,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/reissuance/StockReissuance.md
+++ b/docs/schema_markdown/schema/objects/transactions/reissuance/StockReissuance.md
@@ -88,4 +88,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/release/EquityCompensationRelease.md
+++ b/docs/schema_markdown/schema/objects/transactions/release/EquityCompensationRelease.md
@@ -70,4 +70,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/release/PlanSecurityRelease.md
+++ b/docs/schema_markdown/schema/objects/transactions/release/PlanSecurityRelease.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/release/PlanSecurityRelease](../../../../../../schema/objects/transactions/release/PlanSecurityRelease.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/repricing/EquityCompensationRepricing.md
+++ b/docs/schema_markdown/schema/objects/transactions/repricing/EquityCompensationRepricing.md
@@ -45,4 +45,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/repurchase/StockRepurchase.md
+++ b/docs/schema_markdown/schema/objects/transactions/repurchase/StockRepurchase.md
@@ -64,4 +64,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/retraction/ConvertibleRetraction.md
+++ b/docs/schema_markdown/schema/objects/transactions/retraction/ConvertibleRetraction.md
@@ -52,4 +52,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/retraction/EquityCompensationRetraction.md
+++ b/docs/schema_markdown/schema/objects/transactions/retraction/EquityCompensationRetraction.md
@@ -53,4 +53,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/retraction/PlanSecurityRetraction.md
+++ b/docs/schema_markdown/schema/objects/transactions/retraction/PlanSecurityRetraction.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/retraction/PlanSecurityRetraction](../../../../../../schema/objects/transactions/retraction/PlanSecurityRetraction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/retraction/StockRetraction.md
+++ b/docs/schema_markdown/schema/objects/transactions/retraction/StockRetraction.md
@@ -51,4 +51,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/retraction/WarrantRetraction.md
+++ b/docs/schema_markdown/schema/objects/transactions/retraction/WarrantRetraction.md
@@ -51,4 +51,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.md
+++ b/docs/schema_markdown/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.md
@@ -50,4 +50,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/split/StockClassSplit.md
+++ b/docs/schema_markdown/schema/objects/transactions/split/StockClassSplit.md
@@ -42,4 +42,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/transfer/ConvertibleTransfer.md
+++ b/docs/schema_markdown/schema/objects/transactions/transfer/ConvertibleTransfer.md
@@ -71,4 +71,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/transfer/EquityCompensationTransfer.md
+++ b/docs/schema_markdown/schema/objects/transactions/transfer/EquityCompensationTransfer.md
@@ -63,4 +63,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/transfer/PlanSecurityTransfer.md
+++ b/docs/schema_markdown/schema/objects/transactions/transfer/PlanSecurityTransfer.md
@@ -10,4 +10,4 @@
 
   **Source Code:** [schema/objects/transactions/transfer/PlanSecurityTransfer](../../../../../../schema/objects/transactions/transfer/PlanSecurityTransfer.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/transfer/StockTransfer.md
+++ b/docs/schema_markdown/schema/objects/transactions/transfer/StockTransfer.md
@@ -66,4 +66,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/transfer/WarrantTransfer.md
+++ b/docs/schema_markdown/schema/objects/transactions/transfer/WarrantTransfer.md
@@ -63,4 +63,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/vesting/VestingAcceleration.md
+++ b/docs/schema_markdown/schema/objects/transactions/vesting/VestingAcceleration.md
@@ -41,4 +41,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/vesting/VestingEvent.md
+++ b/docs/schema_markdown/schema/objects/transactions/vesting/VestingEvent.md
@@ -49,4 +49,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/objects/transactions/vesting/VestingStart.md
+++ b/docs/schema_markdown/schema/objects/transactions/vesting/VestingStart.md
@@ -60,4 +60,4 @@
 ]
 ```
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/files/File.md
+++ b/docs/schema_markdown/schema/primitives/files/File.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/files/File](../../../../../schema/primitives/files/File.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/Object.md
+++ b/docs/schema_markdown/schema/primitives/objects/Object.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/primitives/objects/Object](../../../../../schema/primitives/objects/Object.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/IssuerTransaction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/IssuerTransaction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/IssuerTransaction](../../../../../../schema/primitives/objects/transactions/IssuerTransaction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/SecurityTransaction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/SecurityTransaction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/SecurityTransaction](../../../../../../schema/primitives/objects/transactions/SecurityTransaction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/StockClassTransaction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/StockClassTransaction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/StockClassTransaction](../../../../../../schema/primitives/objects/transactions/StockClassTransaction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/StockPlanTransaction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/StockPlanTransaction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/StockPlanTransaction](../../../../../../schema/primitives/objects/transactions/StockPlanTransaction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/Transaction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/Transaction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/Transaction](../../../../../../schema/primitives/objects/transactions/Transaction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/acceptance/Acceptance.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/acceptance/Acceptance.md
@@ -13,4 +13,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/acceptance/Acceptance](../../../../../../../schema/primitives/objects/transactions/acceptance/Acceptance.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/cancellation/Cancellation.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/cancellation/Cancellation.md
@@ -15,4 +15,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/cancellation/Cancellation](../../../../../../../schema/primitives/objects/transactions/cancellation/Cancellation.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/change_event/StakeholderChangeEvent](../../../../../../../schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/consolidation/Consolidation.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/consolidation/Consolidation.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/consolidation/Consolidation](../../../../../../../schema/primitives/objects/transactions/consolidation/Consolidation.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/conversion/Conversion.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/conversion/Conversion.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/conversion/Conversion](../../../../../../../schema/primitives/objects/transactions/conversion/Conversion.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/exercise/Exercise.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/exercise/Exercise.md
@@ -15,4 +15,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/exercise/Exercise](../../../../../../../schema/primitives/objects/transactions/exercise/Exercise.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/issuance/Issuance.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/issuance/Issuance.md
@@ -19,4 +19,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/issuance/Issuance](../../../../../../../schema/primitives/objects/transactions/issuance/Issuance.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/reissuance/Reissuance.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/reissuance/Reissuance.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/reissuance/Reissuance](../../../../../../../schema/primitives/objects/transactions/reissuance/Reissuance.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/release/Release.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/release/Release.md
@@ -18,4 +18,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/release/Release](../../../../../../../schema/primitives/objects/transactions/release/Release.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/repurchase/Repurchase.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/repurchase/Repurchase.md
@@ -17,4 +17,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/repurchase/Repurchase](../../../../../../../schema/primitives/objects/transactions/repurchase/Repurchase.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/retraction/Retraction.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/retraction/Retraction.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/retraction/Retraction](../../../../../../../schema/primitives/objects/transactions/retraction/Retraction.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/return_to_pool/ReturnToPool](../../../../../../../schema/primitives/objects/transactions/return_to_pool/ReturnToPool.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/objects/transactions/transfer/Transfer.md
+++ b/docs/schema_markdown/schema/primitives/objects/transactions/transfer/Transfer.md
@@ -16,4 +16,4 @@
 
 **Source Code:** [schema/primitives/objects/transactions/transfer/Transfer](../../../../../../../schema/primitives/objects/transactions/transfer/Transfer.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/types/conversion_mechanisms/ConversionMechanism.md
+++ b/docs/schema_markdown/schema/primitives/types/conversion_mechanisms/ConversionMechanism.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/types/conversion_mechanisms/ConversionMechanism](../../../../../../schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/types/conversion_rights/ConversionRight.md
+++ b/docs/schema_markdown/schema/primitives/types/conversion_rights/ConversionRight.md
@@ -17,4 +17,4 @@
 
 **Source Code:** [schema/primitives/types/conversion_rights/ConversionRight](../../../../../../schema/primitives/types/conversion_rights/ConversionRight.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/types/conversion_triggers/ConversionTrigger.md
+++ b/docs/schema_markdown/schema/primitives/types/conversion_triggers/ConversionTrigger.md
@@ -18,4 +18,4 @@
 
 **Source Code:** [schema/primitives/types/conversion_triggers/ConversionTrigger](../../../../../../schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/types/vesting/VestingConditionTrigger.md
+++ b/docs/schema_markdown/schema/primitives/types/vesting/VestingConditionTrigger.md
@@ -14,4 +14,4 @@
 
 **Source Code:** [schema/primitives/types/vesting/VestingConditionTrigger](../../../../../../schema/primitives/types/vesting/VestingConditionTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/primitives/types/vesting/VestingPeriod.md
+++ b/docs/schema_markdown/schema/primitives/types/vesting/VestingPeriod.md
@@ -17,4 +17,4 @@
 
 **Source Code:** [schema/primitives/types/vesting/VestingPeriod](../../../../../../schema/primitives/types/vesting/VestingPeriod.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Address.md
+++ b/docs/schema_markdown/schema/types/Address.md
@@ -19,4 +19,4 @@ _Type representation of an address_
 
 **Source Code:** [schema/types/Address](../../../../schema/types/Address.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/CapitalizationDefinition.md
+++ b/docs/schema_markdown/schema/types/CapitalizationDefinition.md
@@ -17,4 +17,4 @@ _Type represents a group of securities that constitutes some formally defined pa
 
 **Source Code:** [schema/types/CapitalizationDefinition](../../../../schema/types/CapitalizationDefinition.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/CapitalizationDefinitionRules.md
+++ b/docs/schema_markdown/schema/types/CapitalizationDefinitionRules.md
@@ -21,4 +21,4 @@ _Type represents the rules for determining the capitalization definition for a s
 
 **Source Code:** [schema/types/CapitalizationDefinitionRules](../../../../schema/types/CapitalizationDefinitionRules.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/ContactInfo.md
+++ b/docs/schema_markdown/schema/types/ContactInfo.md
@@ -16,4 +16,4 @@ _Type representation of a primary contact person for a stakeholder (e.g. a fund)
 
 **Source Code:** [schema/types/ContactInfo](../../../../schema/types/ContactInfo.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/ContactInfoWithoutName.md
+++ b/docs/schema_markdown/schema/types/ContactInfoWithoutName.md
@@ -15,4 +15,4 @@ _Type representation of the contact info for an individual stakeholder_
 
 **Source Code:** [schema/types/ContactInfoWithoutName](../../../../schema/types/ContactInfoWithoutName.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/CountryCode.md
+++ b/docs/schema_markdown/schema/types/CountryCode.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/CountryCode](../../../../schema/types/CountryCode.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/CountrySubdivisionCode.md
+++ b/docs/schema_markdown/schema/types/CountrySubdivisionCode.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/CountrySubdivisionCode](../../../../schema/types/CountrySubdivisionCode.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/CurrencyCode.md
+++ b/docs/schema_markdown/schema/types/CurrencyCode.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/CurrencyCode](../../../../schema/types/CurrencyCode.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Date.md
+++ b/docs/schema_markdown/schema/types/Date.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/Date](../../../../schema/types/Date.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Email.md
+++ b/docs/schema_markdown/schema/types/Email.md
@@ -15,4 +15,4 @@ _Type representation of an email address_
 
 **Source Code:** [schema/types/Email](../../../../schema/types/Email.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/File.md
+++ b/docs/schema_markdown/schema/types/File.md
@@ -15,4 +15,4 @@ _Type representation of a file_
 
 **Source Code:** [schema/types/File](../../../../schema/types/File.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/InterestRate.md
+++ b/docs/schema_markdown/schema/types/InterestRate.md
@@ -16,4 +16,4 @@ _Type representation of an interest rate, including accrual start and end dates_
 
 **Source Code:** [schema/types/InterestRate](../../../../schema/types/InterestRate.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Md5.md
+++ b/docs/schema_markdown/schema/types/Md5.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/Md5](../../../../schema/types/Md5.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Monetary.md
+++ b/docs/schema_markdown/schema/types/Monetary.md
@@ -15,4 +15,4 @@ _Type representation of an amount of money in a specified currency_
 
 **Source Code:** [schema/types/Monetary](../../../../schema/types/Monetary.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Name.md
+++ b/docs/schema_markdown/schema/types/Name.md
@@ -16,4 +16,4 @@ _Type comprising of multiple name components_
 
 **Source Code:** [schema/types/Name](../../../../schema/types/Name.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Numeric.md
+++ b/docs/schema_markdown/schema/types/Numeric.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/Numeric](../../../../schema/types/Numeric.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/ObjectReference.md
+++ b/docs/schema_markdown/schema/types/ObjectReference.md
@@ -15,4 +15,4 @@ _A type representing a reference to any kind of OCF object_
 
 **Source Code:** [schema/types/ObjectReference](../../../../schema/types/ObjectReference.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Percentage.md
+++ b/docs/schema_markdown/schema/types/Percentage.md
@@ -10,4 +10,4 @@
 
 **Source Code:** [schema/types/Percentage](../../../../schema/types/Percentage.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Phone.md
+++ b/docs/schema_markdown/schema/types/Phone.md
@@ -15,4 +15,4 @@ _Type representation of a phone number_
 
 **Source Code:** [schema/types/Phone](../../../../schema/types/Phone.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Ratio.md
+++ b/docs/schema_markdown/schema/types/Ratio.md
@@ -15,4 +15,4 @@ _Type representation of a ratio as two parts of a quotient, i.e. numerator and d
 
 **Source Code:** [schema/types/Ratio](../../../../schema/types/Ratio.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/SecurityExemption.md
+++ b/docs/schema_markdown/schema/types/SecurityExemption.md
@@ -15,4 +15,4 @@ _Type representation of a securities issuance exemption that includes an unstruc
 
 **Source Code:** [schema/types/SecurityExemption](../../../../schema/types/SecurityExemption.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/ShareNumberRange.md
+++ b/docs/schema_markdown/schema/types/ShareNumberRange.md
@@ -15,4 +15,4 @@ _Type representation of a range of share numbers associated with an event (such 
 
 **Source Code:** [schema/types/ShareNumberRange](../../../../schema/types/ShareNumberRange.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/StockParent.md
+++ b/docs/schema_markdown/schema/types/StockParent.md
@@ -15,4 +15,4 @@ _Type representation of the parent security of a given stock issuance (e.g. if a
 
 **Source Code:** [schema/types/StockParent](../../../../schema/types/StockParent.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/TaxID.md
+++ b/docs/schema_markdown/schema/types/TaxID.md
@@ -15,4 +15,4 @@ _Type representation of a government identifier for tax purposes (e.g. EIN) and 
 
 **Source Code:** [schema/types/TaxID](../../../../schema/types/TaxID.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/TerminationWindow.md
+++ b/docs/schema_markdown/schema/types/TerminationWindow.md
@@ -16,4 +16,4 @@ _Type representation of a termination window_
 
 **Source Code:** [schema/types/TerminationWindow](../../../../schema/types/TerminationWindow.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/Vesting.md
+++ b/docs/schema_markdown/schema/types/Vesting.md
@@ -15,4 +15,4 @@ _Describes an exact vesting date and amount_
 
 **Source Code:** [schema/types/Vesting](../../../../schema/types/Vesting.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/CustomConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/CustomConversionMechanism.md
@@ -15,4 +15,4 @@ _Sets forth inputs and conversion mechanism of a custom conversion, a conversion
 
 **Source Code:** [schema/types/conversion_mechanisms/CustomConversionMechanism](../../../../../schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.md
@@ -15,4 +15,4 @@ _Describes how a security converts into a fixed amount of a stock class_
 
 **Source Code:** [schema/types/conversion_mechanisms/FixedAmountConversionMechanism](../../../../../schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/NoteConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/NoteConversionMechanism.md
@@ -25,4 +25,4 @@ _Sets forth inputs and conversion mechanism of a convertible note_
 
 **Source Code:** [schema/types/conversion_mechanisms/NoteConversionMechanism](../../../../../schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.md
@@ -17,4 +17,4 @@ _Sets forth inputs and conversion mechanism of percent of capitalization convers
 
 **Source Code:** [schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism](../../../../../schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/RatioConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/RatioConversionMechanism.md
@@ -17,4 +17,4 @@ _Sets forth inputs and conversion mechanism of a ratio conversion (primarily use
 
 **Source Code:** [schema/types/conversion_mechanisms/RatioConversionMechanism](../../../../../schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/SAFEConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/SAFEConversionMechanism.md
@@ -21,4 +21,4 @@ _Sets forth inputs and conversion mechanism of a SAFE (mirrors the flavors and i
 
 **Source Code:** [schema/types/conversion_mechanisms/SAFEConversionMechanism](../../../../../schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.md
@@ -18,4 +18,4 @@ _Sets forth inputs and conversion mechanism based on price per share of a future
 
 **Source Code:** [schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism](../../../../../schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.md
+++ b/docs/schema_markdown/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.md
@@ -18,4 +18,4 @@ _Sets forth inputs and conversion mechanism based on valuations_
 
 **Source Code:** [schema/types/conversion_mechanisms/ValuationBasedConversionMechanism](../../../../../schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_rights/ConvertibleConversionRight.md
+++ b/docs/schema_markdown/schema/types/conversion_rights/ConvertibleConversionRight.md
@@ -17,4 +17,4 @@ _Type representation of a conversion right from a convertible into another non-p
 
 **Source Code:** [schema/types/conversion_rights/ConvertibleConversionRight](../../../../../schema/types/conversion_rights/ConvertibleConversionRight.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_rights/StockClassConversionRight.md
+++ b/docs/schema_markdown/schema/types/conversion_rights/StockClassConversionRight.md
@@ -17,4 +17,4 @@ _Type representation of a conversion right from one Stock Class into another Sto
 
 **Source Code:** [schema/types/conversion_rights/StockClassConversionRight](../../../../../schema/types/conversion_rights/StockClassConversionRight.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_rights/WarrantConversionRight.md
+++ b/docs/schema_markdown/schema/types/conversion_rights/WarrantConversionRight.md
@@ -17,4 +17,4 @@ _Type representation of a conversion right from a convertible into another non-p
 
 **Source Code:** [schema/types/conversion_rights/WarrantConversionRight](../../../../../schema/types/conversion_rights/WarrantConversionRight.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.md
@@ -19,4 +19,4 @@ _Type representation of automatic trigger on a tive or condition._
 
 **Source Code:** [schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger](../../../../../schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.md
@@ -19,4 +19,4 @@ _Type representation of an automatic trigger on a date._
 
 **Source Code:** [schema/types/conversion_triggers/AutomaticConversionOnDateTrigger](../../../../../schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.md
@@ -18,4 +18,4 @@ _Type representation of elective trigger valid at will (so long as instrument is
 
 **Source Code:** [schema/types/conversion_triggers/ElectiveConversionAtWillTrigger](../../../../../schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.md
@@ -20,4 +20,4 @@ _Type representation of elective trigger valid on or after start_date and until 
 
 **Source Code:** [schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger](../../../../../schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.md
@@ -19,4 +19,4 @@ _Type representation of elective trigger on fulfillment of a condition._
 
 **Source Code:** [schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger](../../../../../schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/conversion_triggers/UnspecifiedConversionTrigger.md
+++ b/docs/schema_markdown/schema/types/conversion_triggers/UnspecifiedConversionTrigger.md
@@ -18,4 +18,4 @@ _Use this where no structured data is available regarding what triggers the conv
 
 **Source Code:** [schema/types/conversion_triggers/UnspecifiedConversionTrigger](../../../../../schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingCondition.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingCondition.md
@@ -19,4 +19,4 @@ _Describes condition / triggers to be satisfied for vesting to occur_
 
 **Source Code:** [schema/types/vesting/VestingCondition](../../../../../schema/types/vesting/VestingCondition.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingConditionPortion.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingConditionPortion.md
@@ -16,4 +16,4 @@ _Describes a fractional portion (ratio) of shares associated with a Vesting Cond
 
 **Source Code:** [schema/types/vesting/VestingConditionPortion](../../../../../schema/types/vesting/VestingConditionPortion.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingEventTrigger.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingEventTrigger.md
@@ -14,4 +14,4 @@ _Describes a vesting condition satisfied when a particular unscheduled event occ
 
 **Source Code:** [schema/types/vesting/VestingEventTrigger](../../../../../schema/types/vesting/VestingEventTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingPeriodInDays.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingPeriodInDays.md
@@ -17,4 +17,4 @@ _Describes a period of time expressed in days (e.g. 365 days) for use in Vesting
 
 **Source Code:** [schema/types/vesting/VestingPeriodInDays](../../../../../schema/types/vesting/VestingPeriodInDays.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingPeriodInMonths.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingPeriodInMonths.md
@@ -18,4 +18,4 @@ _Describes a period of time expressed in months (e.g. 3 months) for use in Vesti
 
 **Source Code:** [schema/types/vesting/VestingPeriodInMonths](../../../../../schema/types/vesting/VestingPeriodInMonths.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingScheduleAbsoluteTrigger.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingScheduleAbsoluteTrigger.md
@@ -15,4 +15,4 @@ _Describes a vesting condition satisfied on an absolute date._
 
 **Source Code:** [schema/types/vesting/VestingScheduleAbsoluteTrigger](../../../../../schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingScheduleRelativeTrigger.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingScheduleRelativeTrigger.md
@@ -16,4 +16,4 @@ _Describes a vesting condition satisfied when a period of time, relative to anot
 
 **Source Code:** [schema/types/vesting/VestingScheduleRelativeTrigger](../../../../../schema/types/vesting/VestingScheduleRelativeTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/docs/schema_markdown/schema/types/vesting/VestingStartTrigger.md
+++ b/docs/schema_markdown/schema/types/vesting/VestingStartTrigger.md
@@ -14,4 +14,4 @@ _Describes a vesting condition satisfied at the security's vesting commencement 
 
 **Source Code:** [schema/types/vesting/VestingStartTrigger](../../../../../schema/types/vesting/VestingStartTrigger.schema.json)
 
-Copyright © 2025 Open Cap Table Coalition.
+Copyright © 2026 Open Cap Table Coalition.

--- a/package-lock.json
+++ b/package-lock.json
@@ -699,12 +699,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -877,9 +875,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1103,20 +1101,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/@jest/core/node_modules/supports-color": {
@@ -1517,20 +1501,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/@jest/transform/node_modules/supports-color": {
@@ -2090,15 +2060,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2446,10 +2417,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2856,10 +2828,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2987,10 +2960,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3158,6 +3132,23 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
@@ -3341,9 +3332,9 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4173,20 +4164,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-config/node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-config/node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4465,20 +4442,6 @@
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/jest-haste-map/node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -4667,20 +4630,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/jest-message-util/node_modules/supports-color": {
@@ -5686,19 +5635,6 @@
         "url": "https://opencollective.com/lint-staged"
       }
     },
-    "node_modules/lint-staged/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/lint-staged/node_modules/supports-color": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.3.1.tgz",
@@ -5843,10 +5779,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -6858,6 +6795,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6868,10 +6819,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7127,10 +7079,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -7227,15 +7180,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -7271,11 +7215,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
@@ -7426,10 +7365,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -8120,15 +8060,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8371,10 +8302,11 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }

--- a/schema/enums/AccrualPeriodType.schema.json
+++ b/schema/enums/AccrualPeriodType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of interest accrual period types",
   "type": "string",
   "enum": ["DAILY", "MONTHLY", "QUARTERLY", "SEMI_ANNUAL", "ANNUAL"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AccrualPeriodType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AccrualPeriodType.schema.json"
 }

--- a/schema/enums/AddressType.schema.json
+++ b/schema/enums/AddressType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of address types",
   "type": "string",
   "enum": ["LEGAL", "CONTACT", "OTHER"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AddressType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AddressType.schema.json"
 }

--- a/schema/enums/AllocationType.schema.json
+++ b/schema/enums/AllocationType.schema.json
@@ -13,5 +13,5 @@
     "BACK_LOADED_TO_SINGLE_TRANCHE",
     "FRACTIONAL"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AllocationType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AllocationType.schema.json"
 }

--- a/schema/enums/AuthorizedShares.schema.json
+++ b/schema/enums/AuthorizedShares.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of authorized shares types",
   "type": "string",
   "enum": ["NOT APPLICABLE", "UNLIMITED"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AuthorizedShares.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/AuthorizedShares.schema.json"
 }

--- a/schema/enums/CompensationType.schema.json
+++ b/schema/enums/CompensationType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of equity compensation types (there are some things around the margins like RSAs that don't currently fit under the EquityCompensation umbrella but might arguably fall under this. If you want to create an RSA, create a stock issuance with vesting - you can link it to a plan as well, if you want).\n\n**The enums stand for:**\n1. OPTION_ISO (qualified)\n2. OPTION_NSO (non-qualified)\n3. OPTION (not NSO or ISO)\n4. RSU (restricted share units)\n5. CSAR(cash-settled stock appreciation rights)\n6. SSAR(stock-settled stock appreciation rights)",
   "type": "string",
   "enum": ["OPTION_NSO", "OPTION_ISO", "OPTION", "RSU", "CSAR", "SSAR"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/CompensationType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/CompensationType.schema.json"
 }

--- a/schema/enums/CompoundingType.schema.json
+++ b/schema/enums/CompoundingType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of interest compounding types",
   "type": "string",
   "enum": ["COMPOUNDING", "SIMPLE"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/CompoundingType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/CompoundingType.schema.json"
 }

--- a/schema/enums/ConversionMechanismType.schema.json
+++ b/schema/enums/ConversionMechanismType.schema.json
@@ -14,5 +14,5 @@
     "CUSTOM_CONVERSION",
     "PPS_BASED_CONVERSION"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionMechanismType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionMechanismType.schema.json"
 }

--- a/schema/enums/ConversionRightType.schema.json
+++ b/schema/enums/ConversionRightType.schema.json
@@ -9,5 +9,5 @@
     "WARRANT_CONVERSION_RIGHT",
     "STOCK_CLASS_CONVERSION_RIGHT"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionRightType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionRightType.schema.json"
 }

--- a/schema/enums/ConversionTimingType.schema.json
+++ b/schema/enums/ConversionTimingType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of convertible conversion timing for calculation purposes (e.g. does the instrument convert based on pre or post money).",
   "type": "string",
   "enum": ["PRE_MONEY", "POST_MONEY"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionTimingType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionTimingType.schema.json"
 }

--- a/schema/enums/ConversionTriggerType.schema.json
+++ b/schema/enums/ConversionTriggerType.schema.json
@@ -12,5 +12,5 @@
     "ELECTIVE_AT_WILL",
     "UNSPECIFIED"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionTriggerType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConversionTriggerType.schema.json"
 }

--- a/schema/enums/ConvertibleType.schema.json
+++ b/schema/enums/ConvertibleType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of convertible instrument types",
   "type": "string",
   "enum": ["NOTE", "SAFE", "CONVERTIBLE_SECURITY"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConvertibleType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ConvertibleType.schema.json"
 }

--- a/schema/enums/DayCountType.schema.json
+++ b/schema/enums/DayCountType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of how the number of days are determined per period",
   "type": "string",
   "enum": ["ACTUAL_365", "30_360"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/DayCountType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/DayCountType.schema.json"
 }

--- a/schema/enums/EmailType.schema.json
+++ b/schema/enums/EmailType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of email types",
   "type": "string",
   "enum": ["PERSONAL", "BUSINESS", "OTHER"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/EmailType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/EmailType.schema.json"
 }

--- a/schema/enums/FileType.schema.json
+++ b/schema/enums/FileType.schema.json
@@ -16,5 +16,5 @@
     "OCF_FINANCINGS_FILE",
     "OCF_DOCUMENTS_FILE"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/FileType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/FileType.schema.json"
 }

--- a/schema/enums/InterestPayoutType.schema.json
+++ b/schema/enums/InterestPayoutType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of interest payout types (e.g. deferred or cash payment)",
   "type": "string",
   "enum": ["DEFERRED", "CASH"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/InterestPayoutType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/InterestPayoutType.schema.json"
 }

--- a/schema/enums/ObjectType.schema.json
+++ b/schema/enums/ObjectType.schema.json
@@ -62,5 +62,5 @@
     "TX_VESTING_START",
     "TX_VESTING_EVENT"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ObjectType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ObjectType.schema.json"
 }

--- a/schema/enums/OptionType.schema.json
+++ b/schema/enums/OptionType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of option types",
   "type": "string",
   "enum": ["NSO", "ISO", "INTL"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/OptionType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/OptionType.schema.json"
 }

--- a/schema/enums/ParentSecurityType.schema.json
+++ b/schema/enums/ParentSecurityType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of parent sources a stock can be issued or created from",
   "type": "string",
   "enum": ["STOCK_PLAN", "STOCK", "WARRANT", "CONVERTIBLE"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ParentSecurityType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ParentSecurityType.schema.json"
 }

--- a/schema/enums/PeriodType.schema.json
+++ b/schema/enums/PeriodType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of time period types",
   "type": "string",
   "enum": ["DAYS", "MONTHS", "YEARS"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/PeriodType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/PeriodType.schema.json"
 }

--- a/schema/enums/PhoneType.schema.json
+++ b/schema/enums/PhoneType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of phone number types",
   "type": "string",
   "enum": ["HOME", "MOBILE", "BUSINESS", "OTHER"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/PhoneType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/PhoneType.schema.json"
 }

--- a/schema/enums/QuantitySourceType.schema.json
+++ b/schema/enums/QuantitySourceType.schema.json
@@ -12,5 +12,5 @@
     "INSTRUMENT_MAX",
     "INSTRUMENT_MIN"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/QuantitySourceType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/QuantitySourceType.schema.json"
 }

--- a/schema/enums/RoundingType.schema.json
+++ b/schema/enums/RoundingType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of rounding types",
   "type": "string",
   "enum": ["CEILING", "FLOOR", "NORMAL"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/RoundingType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/RoundingType.schema.json"
 }

--- a/schema/enums/StakeholderRelationshipType.schema.json
+++ b/schema/enums/StakeholderRelationshipType.schema.json
@@ -19,5 +19,5 @@
     "OFFICER",
     "OTHER"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderRelationshipType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderRelationshipType.schema.json"
 }

--- a/schema/enums/StakeholderStatusType.schema.json
+++ b/schema/enums/StakeholderStatusType.schema.json
@@ -15,5 +15,5 @@
     "TERMINATION_INVOLUNTARY_DISABILITY",
     "TERMINATION_INVOLUNTARY_WITH_CAUSE"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderStatusType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderStatusType.schema.json"
 }

--- a/schema/enums/StakeholderType.schema.json
+++ b/schema/enums/StakeholderType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of stakeholder types - individual (human) or institution (entity)",
   "type": "string",
   "enum": ["INDIVIDUAL", "INSTITUTION"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StakeholderType.schema.json"
 }

--- a/schema/enums/StockClassType.schema.json
+++ b/schema/enums/StockClassType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of stock class types",
   "type": "string",
   "enum": ["COMMON", "PREFERRED"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockClassType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockClassType.schema.json"
 }

--- a/schema/enums/StockIssuanceType.schema.json
+++ b/schema/enums/StockIssuanceType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of issuance types where we want to draw attention to some unique aspect of a stock issuance (e.g. is it an RSA)",
   "type": "string",
   "enum": ["RSA", "FOUNDERS_STOCK"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockIssuanceType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockIssuanceType.schema.json"
 }

--- a/schema/enums/StockPlanCancellationBehaviorType.schema.json
+++ b/schema/enums/StockPlanCancellationBehaviorType.schema.json
@@ -10,5 +10,5 @@
     "HOLD_AS_CAPITAL_STOCK",
     "DEFINED_PER_PLAN_SECURITY"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockPlanCancellationBehaviorType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/StockPlanCancellationBehaviorType.schema.json"
 }

--- a/schema/enums/TerminationWindowType.schema.json
+++ b/schema/enums/TerminationWindowType.schema.json
@@ -13,5 +13,5 @@
     "INVOLUNTARY_DISABILITY",
     "INVOLUNTARY_WITH_CAUSE"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/TerminationWindowType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/TerminationWindowType.schema.json"
 }

--- a/schema/enums/ValuationBasedFormulaType.schema.json
+++ b/schema/enums/ValuationBasedFormulaType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration types of valuation inputs that go into a formula - e.g. use a specified value (`FIXED`), a cap (`VALUATION_CAP`) or actual valuation (`ACTUAL`).",
   "type": "string",
   "enum": ["FIXED", "ACTUAL", "CAP"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ValuationBasedFormulaType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ValuationBasedFormulaType.schema.json"
 }

--- a/schema/enums/ValuationType.schema.json
+++ b/schema/enums/ValuationType.schema.json
@@ -5,5 +5,5 @@
   "description": "Enumeration of valuation types",
   "type": "string",
   "enum": ["409A"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ValuationType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/ValuationType.schema.json"
 }

--- a/schema/enums/VestingDayOfMonth.schema.json
+++ b/schema/enums/VestingDayOfMonth.schema.json
@@ -38,5 +38,5 @@
     "31_OR_LAST_DAY_OF_MONTH",
     "VESTING_START_DAY_OR_LAST_DAY_OF_MONTH"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/VestingDayOfMonth.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/VestingDayOfMonth.schema.json"
 }

--- a/schema/enums/VestingTriggerType.schema.json
+++ b/schema/enums/VestingTriggerType.schema.json
@@ -10,5 +10,5 @@
     "VESTING_SCHEDULE_RELATIVE",
     "VESTING_EVENT"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/VestingTriggerType.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/enums/VestingTriggerType.schema.json"
 }

--- a/schema/files/DocumentsFile.schema.json
+++ b/schema/files/DocumentsFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/DocumentsFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/DocumentsFile.schema.json"
 }

--- a/schema/files/FinancingsFile.schema.json
+++ b/schema/files/FinancingsFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/FinancingsFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/FinancingsFile.schema.json"
 }

--- a/schema/files/OCFManifestFile.schema.json
+++ b/schema/files/OCFManifestFile.schema.json
@@ -126,5 +126,5 @@
     "stakeholders_files"
   ],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/OCFManifestFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/OCFManifestFile.schema.json"
 }

--- a/schema/files/StakeholdersFile.schema.json
+++ b/schema/files/StakeholdersFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StakeholdersFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StakeholdersFile.schema.json"
 }

--- a/schema/files/StockClassesFile.schema.json
+++ b/schema/files/StockClassesFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockClassesFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockClassesFile.schema.json"
 }

--- a/schema/files/StockLegendTemplatesFile.schema.json
+++ b/schema/files/StockLegendTemplatesFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockLegendTemplatesFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockLegendTemplatesFile.schema.json"
 }

--- a/schema/files/StockPlansFile.schema.json
+++ b/schema/files/StockPlansFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockPlansFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/StockPlansFile.schema.json"
 }

--- a/schema/files/TransactionsFile.schema.json
+++ b/schema/files/TransactionsFile.schema.json
@@ -132,5 +132,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/TransactionsFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/TransactionsFile.schema.json"
 }

--- a/schema/files/ValuationsFile.schema.json
+++ b/schema/files/ValuationsFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/ValuationsFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/ValuationsFile.schema.json"
 }

--- a/schema/files/VestingTermsFile.schema.json
+++ b/schema/files/VestingTermsFile.schema.json
@@ -23,5 +23,5 @@
   },
   "additionalProperties": false,
   "required": ["items", "file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/VestingTermsFile.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/files/VestingTermsFile.schema.json"
 }

--- a/schema/objects/Document.schema.json
+++ b/schema/objects/Document.schema.json
@@ -46,5 +46,5 @@
     }
   ],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Document.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Document.schema.json"
 }

--- a/schema/objects/Financing.schema.json
+++ b/schema/objects/Financing.schema.json
@@ -34,5 +34,5 @@
   },
   "additionalProperties": false,
   "required": ["name", "issuance_ids", "date"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Financing.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Financing.schema.json"
 }

--- a/schema/objects/Issuer.schema.json
+++ b/schema/objects/Issuer.schema.json
@@ -93,5 +93,5 @@
   ],
   "additionalProperties": false,
   "required": ["legal_name", "formation_date", "country_of_formation"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Issuer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Issuer.schema.json"
 }

--- a/schema/objects/Stakeholder.schema.json
+++ b/schema/objects/Stakeholder.schema.json
@@ -71,5 +71,5 @@
   },
   "additionalProperties": false,
   "required": ["name", "stakeholder_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Stakeholder.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Stakeholder.schema.json"
 }

--- a/schema/objects/StockClass.schema.json
+++ b/schema/objects/StockClass.schema.json
@@ -88,5 +88,5 @@
     "votes_per_share",
     "seniority"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockClass.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockClass.schema.json"
 }

--- a/schema/objects/StockLegendTemplate.schema.json
+++ b/schema/objects/StockLegendTemplate.schema.json
@@ -26,5 +26,5 @@
   },
   "additionalProperties": false,
   "required": ["name", "text"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockLegendTemplate.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockLegendTemplate.schema.json"
 }

--- a/schema/objects/StockPlan.schema.json
+++ b/schema/objects/StockPlan.schema.json
@@ -67,5 +67,5 @@
   ],
   "additionalProperties": false,
   "required": ["plan_name", "initial_shares_reserved"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockPlan.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/StockPlan.schema.json"
 }

--- a/schema/objects/Valuation.schema.json
+++ b/schema/objects/Valuation.schema.json
@@ -51,5 +51,5 @@
     "valuation_type",
     "stock_class_id"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Valuation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/Valuation.schema.json"
 }

--- a/schema/objects/VestingTerms.schema.json
+++ b/schema/objects/VestingTerms.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["name", "description", "allocation_type", "vesting_conditions"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/VestingTerms.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/VestingTerms.schema.json"
 }

--- a/schema/objects/transactions/acceptance/ConvertibleAcceptance.schema.json
+++ b/schema/objects/transactions/acceptance/ConvertibleAcceptance.schema.json
@@ -29,5 +29,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/ConvertibleAcceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/ConvertibleAcceptance.schema.json"
 }

--- a/schema/objects/transactions/acceptance/EquityCompensationAcceptance.schema.json
+++ b/schema/objects/transactions/acceptance/EquityCompensationAcceptance.schema.json
@@ -33,5 +33,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/EquityCompensationAcceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/EquityCompensationAcceptance.schema.json"
 }

--- a/schema/objects/transactions/acceptance/PlanSecurityAcceptance.schema.json
+++ b/schema/objects/transactions/acceptance/PlanSecurityAcceptance.schema.json
@@ -14,5 +14,5 @@
       "description": "This is done to avoid a breaking change as we work towards a bigger restructure of the equity types in v2.0.0. `TX_PLAN_SECURITY_ACCEPTANCE` will be deprecated in v2.0.0"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/PlanSecurityAcceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/PlanSecurityAcceptance.schema.json"
 }

--- a/schema/objects/transactions/acceptance/StockAcceptance.schema.json
+++ b/schema/objects/transactions/acceptance/StockAcceptance.schema.json
@@ -29,5 +29,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/StockAcceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/StockAcceptance.schema.json"
 }

--- a/schema/objects/transactions/acceptance/WarrantAcceptance.schema.json
+++ b/schema/objects/transactions/acceptance/WarrantAcceptance.schema.json
@@ -29,5 +29,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/WarrantAcceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/acceptance/WarrantAcceptance.schema.json"
 }

--- a/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json
+++ b/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["new_shares_authorized"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json"
 }

--- a/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json
+++ b/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["new_shares_authorized"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json"
 }

--- a/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.schema.json
+++ b/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["new_ratio_conversion_mechanism"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockClassConversionRatioAdjustment.schema.json"
 }

--- a/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.schema.json
+++ b/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["shares_reserved"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/adjustment/StockPlanPoolAdjustment.schema.json"
 }

--- a/schema/objects/transactions/cancellation/ConvertibleCancellation.schema.json
+++ b/schema/objects/transactions/cancellation/ConvertibleCancellation.schema.json
@@ -35,5 +35,5 @@
   },
   "additionalProperties": false,
   "required": ["amount"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/ConvertibleCancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/ConvertibleCancellation.schema.json"
 }

--- a/schema/objects/transactions/cancellation/EquityCompensationCancellation.schema.json
+++ b/schema/objects/transactions/cancellation/EquityCompensationCancellation.schema.json
@@ -39,5 +39,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/EquityCompensationCancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/EquityCompensationCancellation.schema.json"
 }

--- a/schema/objects/transactions/cancellation/PlanSecurityCancellation.schema.json
+++ b/schema/objects/transactions/cancellation/PlanSecurityCancellation.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_CANCELLATION"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/PlanSecurityCancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/PlanSecurityCancellation.schema.json"
 }

--- a/schema/objects/transactions/cancellation/StockCancellation.schema.json
+++ b/schema/objects/transactions/cancellation/StockCancellation.schema.json
@@ -35,5 +35,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/StockCancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/StockCancellation.schema.json"
 }

--- a/schema/objects/transactions/cancellation/WarrantCancellation.schema.json
+++ b/schema/objects/transactions/cancellation/WarrantCancellation.schema.json
@@ -35,5 +35,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/WarrantCancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/cancellation/WarrantCancellation.schema.json"
 }

--- a/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.schema.json
+++ b/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.schema.json
@@ -41,5 +41,5 @@
       "required": ["relationship_ended"]
     }
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/change_event/StakeholderRelationshipChangeEvent.schema.json"
 }

--- a/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.schema.json
+++ b/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["new_status"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/change_event/StakeholderStatusChangeEvent.schema.json"
 }

--- a/schema/objects/transactions/consolidation/StockConsolidation.schema.json
+++ b/schema/objects/transactions/consolidation/StockConsolidation.schema.json
@@ -28,5 +28,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/consolidation/StockConsolidation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/consolidation/StockConsolidation.schema.json"
 }

--- a/schema/objects/transactions/conversion/ConvertibleConversion.schema.json
+++ b/schema/objects/transactions/conversion/ConvertibleConversion.schema.json
@@ -50,5 +50,5 @@
   },
   "additionalProperties": false,
   "required": ["reason_text", "trigger_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/conversion/ConvertibleConversion.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/conversion/ConvertibleConversion.schema.json"
 }

--- a/schema/objects/transactions/conversion/StockConversion.schema.json
+++ b/schema/objects/transactions/conversion/StockConversion.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity_converted"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/conversion/StockConversion.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/conversion/StockConversion.schema.json"
 }

--- a/schema/objects/transactions/exercise/EquityCompensationExercise.schema.json
+++ b/schema/objects/transactions/exercise/EquityCompensationExercise.schema.json
@@ -36,5 +36,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/EquityCompensationExercise.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/EquityCompensationExercise.schema.json"
 }

--- a/schema/objects/transactions/exercise/PlanSecurityExercise.schema.json
+++ b/schema/objects/transactions/exercise/PlanSecurityExercise.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_EXERCISE"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/PlanSecurityExercise.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/PlanSecurityExercise.schema.json"
 }

--- a/schema/objects/transactions/exercise/WarrantExercise.schema.json
+++ b/schema/objects/transactions/exercise/WarrantExercise.schema.json
@@ -35,5 +35,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/WarrantExercise.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/exercise/WarrantExercise.schema.json"
 }

--- a/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json
+++ b/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json
@@ -84,5 +84,5 @@
     "conversion_triggers",
     "seniority"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json"
 }

--- a/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json
+++ b/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json
@@ -162,5 +162,5 @@
     "expiration_date",
     "termination_exercise_windows"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json"
 }

--- a/schema/objects/transactions/issuance/PlanSecurityIssuance.schema.json
+++ b/schema/objects/transactions/issuance/PlanSecurityIssuance.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_ISSUANCE"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/PlanSecurityIssuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/PlanSecurityIssuance.schema.json"
 }

--- a/schema/objects/transactions/issuance/StockIssuance.schema.json
+++ b/schema/objects/transactions/issuance/StockIssuance.schema.json
@@ -87,5 +87,5 @@
   },
   "additionalProperties": false,
   "required": ["stock_class_id", "share_price", "quantity", "stock_legend_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/StockIssuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/StockIssuance.schema.json"
 }

--- a/schema/objects/transactions/issuance/WarrantIssuance.schema.json
+++ b/schema/objects/transactions/issuance/WarrantIssuance.schema.json
@@ -97,5 +97,5 @@
   },
   "additionalProperties": false,
   "required": ["exercise_triggers", "purchase_price"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/WarrantIssuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/issuance/WarrantIssuance.schema.json"
 }

--- a/schema/objects/transactions/reissuance/StockReissuance.schema.json
+++ b/schema/objects/transactions/reissuance/StockReissuance.schema.json
@@ -32,5 +32,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/reissuance/StockReissuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/reissuance/StockReissuance.schema.json"
 }

--- a/schema/objects/transactions/release/EquityCompensationRelease.schema.json
+++ b/schema/objects/transactions/release/EquityCompensationRelease.schema.json
@@ -35,5 +35,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/release/EquityCompensationRelease.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/release/EquityCompensationRelease.schema.json"
 }

--- a/schema/objects/transactions/release/PlanSecurityRelease.schema.json
+++ b/schema/objects/transactions/release/PlanSecurityRelease.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_RELEASE"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/release/PlanSecurityRelease.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/release/PlanSecurityRelease.schema.json"
 }

--- a/schema/objects/transactions/repricing/EquityCompensationRepricing.schema.json
+++ b/schema/objects/transactions/repricing/EquityCompensationRepricing.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["new_exercise_price"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/repricing/EquityCompensationRepricing.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/repricing/EquityCompensationRepricing.schema.json"
 }

--- a/schema/objects/transactions/repurchase/StockRepurchase.schema.json
+++ b/schema/objects/transactions/repurchase/StockRepurchase.schema.json
@@ -33,5 +33,5 @@
   },
   "additionalProperties": false,
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/repurchase/StockRepurchase.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/repurchase/StockRepurchase.schema.json"
 }

--- a/schema/objects/transactions/retraction/ConvertibleRetraction.schema.json
+++ b/schema/objects/transactions/retraction/ConvertibleRetraction.schema.json
@@ -29,5 +29,5 @@
     "reason_text": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/ConvertibleRetraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/ConvertibleRetraction.schema.json"
 }

--- a/schema/objects/transactions/retraction/EquityCompensationRetraction.schema.json
+++ b/schema/objects/transactions/retraction/EquityCompensationRetraction.schema.json
@@ -33,5 +33,5 @@
     "reason_text": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/EquityCompensationRetraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/EquityCompensationRetraction.schema.json"
 }

--- a/schema/objects/transactions/retraction/PlanSecurityRetraction.schema.json
+++ b/schema/objects/transactions/retraction/PlanSecurityRetraction.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_RETRACTION"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/PlanSecurityRetraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/PlanSecurityRetraction.schema.json"
 }

--- a/schema/objects/transactions/retraction/StockRetraction.schema.json
+++ b/schema/objects/transactions/retraction/StockRetraction.schema.json
@@ -29,5 +29,5 @@
     "reason_text": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/StockRetraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/StockRetraction.schema.json"
 }

--- a/schema/objects/transactions/retraction/WarrantRetraction.schema.json
+++ b/schema/objects/transactions/retraction/WarrantRetraction.schema.json
@@ -29,5 +29,5 @@
     "reason_text": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/WarrantRetraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/retraction/WarrantRetraction.schema.json"
 }

--- a/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.schema.json
+++ b/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.schema.json
@@ -34,5 +34,5 @@
     "stock_plan_id": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/return_to_pool/StockPlanReturnToPool.schema.json"
 }

--- a/schema/objects/transactions/split/StockClassSplit.schema.json
+++ b/schema/objects/transactions/split/StockClassSplit.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["split_ratio"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/split/StockClassSplit.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/split/StockClassSplit.schema.json"
 }

--- a/schema/objects/transactions/transfer/ConvertibleTransfer.schema.json
+++ b/schema/objects/transactions/transfer/ConvertibleTransfer.schema.json
@@ -36,5 +36,5 @@
   },
   "additionalProperties": false,
   "required": ["amount"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/ConvertibleTransfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/ConvertibleTransfer.schema.json"
 }

--- a/schema/objects/transactions/transfer/EquityCompensationTransfer.schema.json
+++ b/schema/objects/transactions/transfer/EquityCompensationTransfer.schema.json
@@ -37,5 +37,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/EquityCompensationTransfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/EquityCompensationTransfer.schema.json"
 }

--- a/schema/objects/transactions/transfer/PlanSecurityTransfer.schema.json
+++ b/schema/objects/transactions/transfer/PlanSecurityTransfer.schema.json
@@ -13,5 +13,5 @@
       "const": "TX_PLAN_SECURITY_TRANSFER"
     }
   },
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/PlanSecurityTransfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/PlanSecurityTransfer.schema.json"
 }

--- a/schema/objects/transactions/transfer/StockTransfer.schema.json
+++ b/schema/objects/transactions/transfer/StockTransfer.schema.json
@@ -36,5 +36,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/StockTransfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/StockTransfer.schema.json"
 }

--- a/schema/objects/transactions/transfer/WarrantTransfer.schema.json
+++ b/schema/objects/transactions/transfer/WarrantTransfer.schema.json
@@ -36,5 +36,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/WarrantTransfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/transfer/WarrantTransfer.schema.json"
 }

--- a/schema/objects/transactions/vesting/VestingAcceleration.schema.json
+++ b/schema/objects/transactions/vesting/VestingAcceleration.schema.json
@@ -34,5 +34,5 @@
   },
   "additionalProperties": false,
   "required": ["quantity", "reason_text"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingAcceleration.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingAcceleration.schema.json"
 }

--- a/schema/objects/transactions/vesting/VestingEvent.schema.json
+++ b/schema/objects/transactions/vesting/VestingEvent.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["vesting_condition_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingEvent.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingEvent.schema.json"
 }

--- a/schema/objects/transactions/vesting/VestingStart.schema.json
+++ b/schema/objects/transactions/vesting/VestingStart.schema.json
@@ -30,5 +30,5 @@
   },
   "additionalProperties": false,
   "required": ["vesting_condition_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingStart.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/objects/transactions/vesting/VestingStart.schema.json"
 }

--- a/schema/primitives/files/File.schema.json
+++ b/schema/primitives/files/File.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["file_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/files/File.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/files/File.schema.json"
 }

--- a/schema/primitives/objects/Object.schema.json
+++ b/schema/primitives/objects/Object.schema.json
@@ -22,5 +22,5 @@
     }
   },
   "required": ["id", "object_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/Object.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/Object.schema.json"
 }

--- a/schema/primitives/objects/transactions/IssuerTransaction.schema.json
+++ b/schema/primitives/objects/transactions/IssuerTransaction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["issuer_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/IssuerTransaction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/IssuerTransaction.schema.json"
 }

--- a/schema/primitives/objects/transactions/SecurityTransaction.schema.json
+++ b/schema/primitives/objects/transactions/SecurityTransaction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["security_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/SecurityTransaction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/SecurityTransaction.schema.json"
 }

--- a/schema/primitives/objects/transactions/StockClassTransaction.schema.json
+++ b/schema/primitives/objects/transactions/StockClassTransaction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["stock_class_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/StockClassTransaction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/StockClassTransaction.schema.json"
 }

--- a/schema/primitives/objects/transactions/StockPlanTransaction.schema.json
+++ b/schema/primitives/objects/transactions/StockPlanTransaction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["stock_plan_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/StockPlanTransaction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/StockPlanTransaction.schema.json"
 }

--- a/schema/primitives/objects/transactions/Transaction.schema.json
+++ b/schema/primitives/objects/transactions/Transaction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["date"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/Transaction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/Transaction.schema.json"
 }

--- a/schema/primitives/objects/transactions/acceptance/Acceptance.schema.json
+++ b/schema/primitives/objects/transactions/acceptance/Acceptance.schema.json
@@ -6,5 +6,5 @@
   "type": "object",
   "properties": {},
   "required": [],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/acceptance/Acceptance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/acceptance/Acceptance.schema.json"
 }

--- a/schema/primitives/objects/transactions/cancellation/Cancellation.schema.json
+++ b/schema/primitives/objects/transactions/cancellation/Cancellation.schema.json
@@ -15,5 +15,5 @@
     }
   },
   "required": ["reason_text"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/cancellation/Cancellation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/cancellation/Cancellation.schema.json"
 }

--- a/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.schema.json
+++ b/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["stakeholder_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/change_event/StakeholderChangeEvent.schema.json"
 }

--- a/schema/primitives/objects/transactions/consolidation/Consolidation.schema.json
+++ b/schema/primitives/objects/transactions/consolidation/Consolidation.schema.json
@@ -26,5 +26,5 @@
     }
   },
   "required": ["resulting_security_id", "security_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/consolidation/Consolidation.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/consolidation/Consolidation.schema.json"
 }

--- a/schema/primitives/objects/transactions/conversion/Conversion.schema.json
+++ b/schema/primitives/objects/transactions/conversion/Conversion.schema.json
@@ -15,5 +15,5 @@
     }
   },
   "required": ["resulting_security_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/conversion/Conversion.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/conversion/Conversion.schema.json"
 }

--- a/schema/primitives/objects/transactions/exercise/Exercise.schema.json
+++ b/schema/primitives/objects/transactions/exercise/Exercise.schema.json
@@ -19,5 +19,5 @@
     }
   },
   "required": ["resulting_security_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/exercise/Exercise.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/exercise/Exercise.schema.json"
 }

--- a/schema/primitives/objects/transactions/issuance/Issuance.schema.json
+++ b/schema/primitives/objects/transactions/issuance/Issuance.schema.json
@@ -35,5 +35,5 @@
     }
   },
   "required": ["security_law_exemptions", "stakeholder_id", "custom_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/issuance/Issuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/issuance/Issuance.schema.json"
 }

--- a/schema/primitives/objects/transactions/reissuance/Reissuance.schema.json
+++ b/schema/primitives/objects/transactions/reissuance/Reissuance.schema.json
@@ -25,5 +25,5 @@
     }
   },
   "required": ["resulting_security_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/reissuance/Reissuance.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/reissuance/Reissuance.schema.json"
 }

--- a/schema/primitives/objects/transactions/release/Release.schema.json
+++ b/schema/primitives/objects/transactions/release/Release.schema.json
@@ -36,5 +36,5 @@
     "quantity",
     "resulting_security_ids"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/release/Release.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/release/Release.schema.json"
 }

--- a/schema/primitives/objects/transactions/repurchase/Repurchase.schema.json
+++ b/schema/primitives/objects/transactions/repurchase/Repurchase.schema.json
@@ -23,5 +23,5 @@
     }
   },
   "required": ["price", "quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/repurchase/Repurchase.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/repurchase/Repurchase.schema.json"
 }

--- a/schema/primitives/objects/transactions/retraction/Retraction.schema.json
+++ b/schema/primitives/objects/transactions/retraction/Retraction.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["reason_text"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/retraction/Retraction.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/retraction/Retraction.schema.json"
 }

--- a/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.schema.json
+++ b/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.schema.json
@@ -19,5 +19,5 @@
     }
   },
   "required": ["reason_text", "stock_plan_id", "quantity"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/return_to_pool/ReturnToPool.schema.json"
 }

--- a/schema/primitives/objects/transactions/transfer/Transfer.schema.json
+++ b/schema/primitives/objects/transactions/transfer/Transfer.schema.json
@@ -25,5 +25,5 @@
     }
   },
   "required": ["resulting_security_ids"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/transfer/Transfer.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/objects/transactions/transfer/Transfer.schema.json"
 }

--- a/schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json
+++ b/schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_mechanisms/ConversionMechanism.schema.json"
 }

--- a/schema/primitives/types/conversion_rights/ConversionRight.schema.json
+++ b/schema/primitives/types/conversion_rights/ConversionRight.schema.json
@@ -48,5 +48,5 @@
     }
   },
   "required": ["conversion_mechanism"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_rights/ConversionRight.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_rights/ConversionRight.schema.json"
 }

--- a/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json
+++ b/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json
@@ -37,5 +37,5 @@
     }
   },
   "required": ["type", "trigger_id", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/conversion_triggers/ConversionTrigger.schema.json"
 }

--- a/schema/primitives/types/vesting/VestingConditionTrigger.schema.json
+++ b/schema/primitives/types/vesting/VestingConditionTrigger.schema.json
@@ -11,5 +11,5 @@
     }
   },
   "required": ["type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/vesting/VestingConditionTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/vesting/VestingConditionTrigger.schema.json"
 }

--- a/schema/primitives/types/vesting/VestingPeriod.schema.json
+++ b/schema/primitives/types/vesting/VestingPeriod.schema.json
@@ -26,5 +26,5 @@
     }
   },
   "required": ["length", "type", "occurrences"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/vesting/VestingPeriod.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/primitives/types/vesting/VestingPeriod.schema.json"
 }

--- a/schema/types/Address.schema.json
+++ b/schema/types/Address.schema.json
@@ -32,5 +32,5 @@
   },
   "additionalProperties": false,
   "required": ["address_type", "country"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Address.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Address.schema.json"
 }

--- a/schema/types/CapitalizationDefinition.schema.json
+++ b/schema/types/CapitalizationDefinition.schema.json
@@ -41,5 +41,5 @@
     "include_security_ids",
     "exclude_security_ids"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CapitalizationDefinition.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CapitalizationDefinition.schema.json"
 }

--- a/schema/types/CapitalizationDefinitionRules.schema.json
+++ b/schema/types/CapitalizationDefinitionRules.schema.json
@@ -49,5 +49,5 @@
     "include_additional_option_pool_topup",
     "include_new_money"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CapitalizationDefinitionRules.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CapitalizationDefinitionRules.schema.json"
 }

--- a/schema/types/ContactInfo.schema.json
+++ b/schema/types/ContactInfo.schema.json
@@ -35,5 +35,5 @@
       "required": ["name", "emails"]
     }
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ContactInfo.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ContactInfo.schema.json"
 }

--- a/schema/types/ContactInfoWithoutName.schema.json
+++ b/schema/types/ContactInfoWithoutName.schema.json
@@ -31,5 +31,5 @@
       "required": ["emails"]
     }
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ContactInfoWithoutName.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ContactInfoWithoutName.schema.json"
 }

--- a/schema/types/CountryCode.schema.json
+++ b/schema/types/CountryCode.schema.json
@@ -7,5 +7,5 @@
   "minLength": 2,
   "maxLength": 2,
   "pattern": "^[A-Z]{2}$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CountryCode.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CountryCode.schema.json"
 }

--- a/schema/types/CountrySubdivisionCode.schema.json
+++ b/schema/types/CountrySubdivisionCode.schema.json
@@ -7,5 +7,5 @@
   "minLength": 1,
   "maxLength": 3,
   "pattern": "^[A-Z0-9]{1,}$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CountrySubdivisionCode.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CountrySubdivisionCode.schema.json"
 }

--- a/schema/types/CurrencyCode.schema.json
+++ b/schema/types/CurrencyCode.schema.json
@@ -7,5 +7,5 @@
   "minLength": 3,
   "maxLength": 3,
   "pattern": "^[A-Z]{3}$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CurrencyCode.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/CurrencyCode.schema.json"
 }

--- a/schema/types/Date.schema.json
+++ b/schema/types/Date.schema.json
@@ -5,5 +5,5 @@
   "description": "Type represention of an ISO-8601 date, e.g. 2022-01-28",
   "type": "string",
   "format": "date",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Date.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Date.schema.json"
 }

--- a/schema/types/Email.schema.json
+++ b/schema/types/Email.schema.json
@@ -17,5 +17,5 @@
   },
   "additionalProperties": false,
   "required": ["email_type", "email_address"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Email.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Email.schema.json"
 }

--- a/schema/types/File.schema.json
+++ b/schema/types/File.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["filepath", "md5"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/File.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/File.schema.json"
 }

--- a/schema/types/InterestRate.schema.json
+++ b/schema/types/InterestRate.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["rate", "accrual_start_date"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/InterestRate.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/InterestRate.schema.json"
 }

--- a/schema/types/Md5.schema.json
+++ b/schema/types/Md5.schema.json
@@ -5,5 +5,5 @@
   "description": "String representation of MD5 hash with basic validation for a string of 32 characters composed of letters (uppercase or lowercase) and numbers",
   "type": "string",
   "pattern": "^[a-fA-F0-9]{32}$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Md5.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Md5.schema.json"
 }

--- a/schema/types/Monetary.schema.json
+++ b/schema/types/Monetary.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["amount", "currency"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Monetary.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Monetary.schema.json"
 }

--- a/schema/types/Name.schema.json
+++ b/schema/types/Name.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["legal_name"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Name.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Name.schema.json"
 }

--- a/schema/types/Numeric.schema.json
+++ b/schema/types/Numeric.schema.json
@@ -5,5 +5,5 @@
   "description": "Fixed-point string representation of a number (up to 10 decimal places supported)",
   "type": "string",
   "pattern": "^[+-]?[0-9]+(\\.[0-9]{1,10})?$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Numeric.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Numeric.schema.json"
 }

--- a/schema/types/ObjectReference.schema.json
+++ b/schema/types/ObjectReference.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["object_type", "object_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ObjectReference.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ObjectReference.schema.json"
 }

--- a/schema/types/Percentage.schema.json
+++ b/schema/types/Percentage.schema.json
@@ -5,5 +5,5 @@
   "description": "Fixed-point string representation of a percentage as a decimal between 0.0 and 1.0 (up to 10 decimal places supported)",
   "type": "string",
   "pattern": "^0?(\\.[0-9]{1,10})?$|^1(\\.0{1,10})?$",
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Percentage.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Percentage.schema.json"
 }

--- a/schema/types/Phone.schema.json
+++ b/schema/types/Phone.schema.json
@@ -17,5 +17,5 @@
   },
   "additionalProperties": false,
   "required": ["phone_type", "phone_number"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Phone.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Phone.schema.json"
 }

--- a/schema/types/Ratio.schema.json
+++ b/schema/types/Ratio.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["numerator", "denominator"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Ratio.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Ratio.schema.json"
 }

--- a/schema/types/SecurityExemption.schema.json
+++ b/schema/types/SecurityExemption.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["description", "jurisdiction"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/SecurityExemption.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/SecurityExemption.schema.json"
 }

--- a/schema/types/ShareNumberRange.schema.json
+++ b/schema/types/ShareNumberRange.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["starting_share_number", "ending_share_number"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ShareNumberRange.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/ShareNumberRange.schema.json"
 }

--- a/schema/types/StockParent.schema.json
+++ b/schema/types/StockParent.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["parent_object_type", "parent_object_id"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/StockParent.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/StockParent.schema.json"
 }

--- a/schema/types/TaxID.schema.json
+++ b/schema/types/TaxID.schema.json
@@ -16,5 +16,5 @@
   },
   "additionalProperties": false,
   "required": ["tax_id", "country"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TaxID.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TaxID.schema.json"
 }

--- a/schema/types/TerminationWindow.schema.json
+++ b/schema/types/TerminationWindow.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["reason", "period", "period_type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TerminationWindow.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/TerminationWindow.schema.json"
 }

--- a/schema/types/Vesting.schema.json
+++ b/schema/types/Vesting.schema.json
@@ -16,5 +16,5 @@
   },
   "required": ["date", "amount"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Vesting.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/Vesting.schema.json"
 }

--- a/schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["type", "custom_conversion_description"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/CustomConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["converts_to_quantity", "type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/FixedAmountConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json
@@ -71,5 +71,5 @@
     "interest_accrual_period",
     "compounding_type"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/NoteConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json
@@ -28,5 +28,5 @@
   },
   "additionalProperties": false,
   "required": ["converts_to_percent", "type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/PercentCapitalizationConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json
@@ -28,5 +28,5 @@
   },
   "additionalProperties": false,
   "required": ["ratio", "conversion_price", "rounding_type", "type"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/RatioConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json
@@ -44,5 +44,5 @@
   },
   "required": ["conversion_mfn", "type"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/SAFEConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.schema.json
@@ -66,5 +66,5 @@
   ],
   "required": ["type", "description"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/SharePriceBasedConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.schema.json
+++ b/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.schema.json
@@ -56,5 +56,5 @@
   ],
   "required": ["type", "valuation_type"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_mechanisms/ValuationBasedConversionMechanism.schema.json"
 }

--- a/schema/types/conversion_rights/ConvertibleConversionRight.schema.json
+++ b/schema/types/conversion_rights/ConvertibleConversionRight.schema.json
@@ -37,5 +37,5 @@
   },
   "additionalProperties": false,
   "required": ["conversion_mechanism"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/ConvertibleConversionRight.schema.json"
 }

--- a/schema/types/conversion_rights/StockClassConversionRight.schema.json
+++ b/schema/types/conversion_rights/StockClassConversionRight.schema.json
@@ -25,5 +25,5 @@
   },
   "additionalProperties": false,
   "required": ["conversion_mechanism"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/StockClassConversionRight.schema.json"
 }

--- a/schema/types/conversion_rights/WarrantConversionRight.schema.json
+++ b/schema/types/conversion_rights/WarrantConversionRight.schema.json
@@ -38,5 +38,5 @@
   },
   "additionalProperties": false,
   "required": ["conversion_mechanism"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_rights/WarrantConversionRight.schema.json"
 }

--- a/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json
+++ b/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json
@@ -24,5 +24,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_condition", "type", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/AutomaticConversionOnConditionTrigger.schema.json"
 }

--- a/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json
+++ b/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json
@@ -24,5 +24,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_date", "type", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/AutomaticConversionOnDateTrigger.schema.json"
 }

--- a/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id", "type", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionAtWillTrigger.schema.json"
 }

--- a/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json
@@ -34,5 +34,5 @@
     "end_date",
     "conversion_right"
   ],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionInDateRangeTrigger.schema.json"
 }

--- a/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json
+++ b/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json
@@ -24,5 +24,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id", "trigger_condition", "type", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/ElectiveConversionOnConditionTrigger.schema.json"
 }

--- a/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json
+++ b/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json
@@ -20,5 +20,5 @@
   },
   "additionalProperties": false,
   "required": ["trigger_id", "type", "conversion_right"],
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/conversion_triggers/UnspecifiedConversionTrigger.schema.json"
 }

--- a/schema/types/vesting/VestingCondition.schema.json
+++ b/schema/types/vesting/VestingCondition.schema.json
@@ -58,5 +58,5 @@
     }
   ],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingCondition.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingCondition.schema.json"
 }

--- a/schema/types/vesting/VestingConditionPortion.schema.json
+++ b/schema/types/vesting/VestingConditionPortion.schema.json
@@ -21,5 +21,5 @@
   },
   "required": ["numerator", "denominator"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingConditionPortion.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingConditionPortion.schema.json"
 }

--- a/schema/types/vesting/VestingEventTrigger.schema.json
+++ b/schema/types/vesting/VestingEventTrigger.schema.json
@@ -15,5 +15,5 @@
     }
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingEventTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingEventTrigger.schema.json"
 }

--- a/schema/types/vesting/VestingPeriodInDays.schema.json
+++ b/schema/types/vesting/VestingPeriodInDays.schema.json
@@ -18,5 +18,5 @@
     "cliff_installment": {}
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInDays.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInDays.schema.json"
 }

--- a/schema/types/vesting/VestingPeriodInMonths.schema.json
+++ b/schema/types/vesting/VestingPeriodInMonths.schema.json
@@ -23,5 +23,5 @@
   },
   "required": ["day_of_month"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInMonths.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingPeriodInMonths.schema.json"
 }

--- a/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json
+++ b/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json
@@ -20,5 +20,5 @@
   },
   "required": ["date"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingScheduleAbsoluteTrigger.schema.json"
 }

--- a/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json
+++ b/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json
@@ -31,5 +31,5 @@
   },
   "required": ["period", "relative_to_condition_id"],
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingScheduleRelativeTrigger.schema.json"
 }

--- a/schema/types/vesting/VestingStartTrigger.schema.json
+++ b/schema/types/vesting/VestingStartTrigger.schema.json
@@ -15,5 +15,5 @@
     }
   },
   "additionalProperties": false,
-  "$comment": "Copyright © 2025 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingStartTrigger.schema.json"
+  "$comment": "Copyright © 2026 Open Cap Table Coalition (https://opencaptablecoalition.com) / Original File: https://github.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/tree/main/schema/types/vesting/VestingStartTrigger.schema.json"
 }


### PR DESCRIPTION
## Summary

Fixes 13 open GitHub Dependabot NPM alerts by running `npm audit fix` to update transitive dependencies in `package-lock.json`. No changes to `package.json`.

| Package | Before | After | Alerts resolved |
|---------|--------|-------|----------------|
| `handlebars` | ≤4.7.8 | 4.7.9 | #94 #95 #96 #98 #99 #100 #101 (CRITICAL→LOW) |
| `lodash` | ≤4.17.23 | 4.18.1 | #78 #103 #104 (HIGH + MODERATE) |
| `minimatch` | ≤3.1.3 | 3.1.5 | #86 (HIGH) |
| `@babel/runtime` | <7.26.10 | 7.29.2 | #66 (MODERATE) |
| `picomatch` | <2.3.2 | 2.3.2 | #91 (MODERATE) |
| `js-yaml` | <3.14.2 | 4.1.1 | #70 (MODERATE) |

> **Note:** 6 moderate `@octokit/*` vulnerabilities remain after this fix. These require a major version bump of `@actions/github` (v5 → v9) and are not currently flagged by GitHub Dependabot. They can be addressed in a follow-up.

## Test plan

- [ ] Confirm CI passes (tests, linting, schema validation)
- [ ] Confirm GitHub Dependabot NPM alerts #66, #70, #78, #86, #91, #94–#101, #103, #104 are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)