### PR TITLE
Extract SchemaComposer utility and add schema:compose CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "schema:validate-ocf-file-schemas": "node --loader ts-node/esm --no-warnings --experimental-json-modules ./utils/validate.mjs validate-ocf-schema -v -t",
     "schema:validate-example-ocf-files": "node --loader ts-node/esm --no-warnings --experimental-json-modules ./utils/validate.mjs validate-ocf-directory -v -p ./samples -t",
     "schema:validate-all-objects-have-samples": "node --loader ts-node/esm --no-warnings --experimental-json-modules ./utils/validate.mjs validate-all-objects-have-samples -t",
+    "schema:compose": "node --loader ts-node/esm --no-warnings --experimental-json-modules ./utils/schema-utils/ComposeSchemas.ts",
     "test": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest",
     "test:watch": "node --experimental-vm-modules --experimental-json-modules --no-warnings node_modules/.bin/jest --watch"
   },

--- a/utils/generate-docs/Schema/Schema.ts
+++ b/utils/generate-docs/Schema/Schema.ts
@@ -11,6 +11,7 @@ import SchemaNodeFactory, {
   SchemaNode,
   SchemaNodeJson,
 } from "./SchemaNode/Factory.js";
+import { composeAll } from "../../schema-utils/SchemaComposer.js";
 
 export type { SchemaNodeJson };
 export type { ExampleJson };
@@ -53,8 +54,11 @@ export default class Schema {
     exampleJsons: ExampleJson[] = [],
     supplementalMarkdowns: string[] = []
   ) {
-    this.schemaNodes = schemaNodeJsons.map((json: SchemaNodeJson) =>
-      SchemaNodeFactory.build(this, json)
+    const { composed } = composeAll(schemaNodeJsons as any[], {
+      onMissingRef: "skip",
+    });
+    this.schemaNodes = composed.map((json) =>
+      SchemaNodeFactory.build(this, json as unknown as SchemaNodeJson)
     );
     this.examples = new Examples(exampleJsons);
     this.supplementals = new Supplementals(supplementalMarkdowns);

--- a/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.test.ts
+++ b/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.test.ts
@@ -37,10 +37,9 @@ describe("BackwardsCompatibleObjectSchemaNode", () => {
         BASE_OBJECT_SCHEMA_NODE_FIXTURE,
         OBJECT_SCHEMA_NODE_FIXTURE,
       ]);
-      const actual = new BackwardsCompatibleObjectSchemaNode(
-        schema,
-        BACKWARDS_COMPATIBLE_OBJECT_SCHEMA_NODE_FIXTURE
-      ).markdownOutput();
+      const actual = schema
+        .findSchemaNodeById(BACKWARDS_COMPATIBLE_OBJECT_SCHEMA_NODE_FIXTURE.$id)
+        .markdownOutput();
 
       let copyright_year = new Date().getFullYear();
 

--- a/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.ts
+++ b/utils/generate-docs/Schema/SchemaNode/BackwardsCompatibleObjectSchemaNode.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { relativePathToOtherPath } from "../../../schema-utils/PathTools.js";
 
 import Schema from "../Schema.js";
-import { PropertyJson } from "./Property/Factory.js";
 import SchemaNode from "./SchemaNode.js";
 
 export interface BackwardsCompatibleObjectSchemaNodeJson {
@@ -43,18 +42,6 @@ export default class BackwardsCompatibleObjectSchemaNode extends SchemaNode {
   protected allOf = (): SchemaNode[] => [];
 
   protected allOfMarkdown = (): string => "";
-
-  /**
-   * Only those properties that are defined directly in the JSON (as opposed to
-   * those that are left blank and meant to be inherited from the allOf array).
-   */
-  protected directProperties = () => {
-    return {};
-  };
-
-  protected allOfPropertiesJson = (): { [id: string]: PropertyJson } => {
-    return {};
-  };
 
   protected markdownExamples = (): string | null => null;
 

--- a/utils/generate-docs/Schema/SchemaNode/Object.test.ts
+++ b/utils/generate-docs/Schema/SchemaNode/Object.test.ts
@@ -76,10 +76,9 @@ describe("Object", () => {
         BASE_OBJECT_SCHEMA_NODE_FIXTURE,
         OBJECT_SCHEMA_NODE_FIXTURE,
       ]);
-      const actual = new Object(
-        schema,
-        OBJECT_SCHEMA_NODE_FIXTURE
-      ).markdownOutput();
+      const actual = schema
+        .findSchemaNodeById(OBJECT_SCHEMA_NODE_FIXTURE.$id)
+        .markdownOutput();
 
       let copyright_year = new Date().getFullYear();
 

--- a/utils/generate-docs/Schema/SchemaNode/SchemaNode.ts
+++ b/utils/generate-docs/Schema/SchemaNode/SchemaNode.ts
@@ -61,26 +61,6 @@ export default abstract class SchemaNode {
       )
       .join("\n");
 
-  /**
-   * Only those properties that are defined directly in the JSON (as opposed to
-   * those that are left blank and meant to be inherited from the allOf array).
-   */
-  protected directProperties = () =>
-    Object.fromEntries(
-      Object.entries(this.json["properties"] || {}).filter(
-        ([_id, json]) => Object.keys(json).length > 0
-      )
-    );
-
-  protected allOfPropertiesJson = (): { [id: string]: PropertyJson } =>
-    this.allOf().reduce(
-      (previousPropertiesJson, schemaNode) => ({
-        ...previousPropertiesJson,
-        ...schemaNode.propertiesJson(),
-      }),
-      {}
-    );
-
   protected markdownExamples = (): string | null => null;
 
   protected supplementalMarkdowns = (): string[] =>
@@ -127,17 +107,12 @@ export default abstract class SchemaNode {
   propertiesJson = () => this.json["properties"];
 
   properties = () =>
-    Object.entries({
-      ...this.allOfPropertiesJson(),
-      ...this.directProperties(),
-    }).map(([id, json]: [string, PropertyJson]) =>
-      PropertyFactory.build(this.schema, json, id)
+    Object.entries(this.json["properties"] || {}).map(
+      ([id, json]: [string, PropertyJson]) =>
+        PropertyFactory.build(this.schema, json, id)
     );
 
-  required = (): string[] => [
-    ...(this.json["required"] || []),
-    ...this.allOf().flatMap((schemaNode) => schemaNode.required()),
-  ];
+  required = (): string[] => this.json["required"] || [];
 
   markdownHeader = () => `### ${this.title()}
 

--- a/utils/schema-utils/ComposeSchemas.ts
+++ b/utils/schema-utils/ComposeSchemas.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * `npm run schema:compose -- --out <dir>`
+ *
+ * Walks every `.schema.json` under `/schema`, composes each via the
+ * `SchemaComposer` (flattening `allOf` ancestor chains into a single,
+ * self-contained schema), and writes the result to `<dir>`, mirroring the
+ * source directory layout. Backwards-compatibility wrapper schemas are
+ * passed through unchanged, matching the semantics used by the doc
+ * generator.
+ *
+ * Use this when you want a flat, self-contained view of every OCF object
+ * for downstream consumers (codegen, ad-hoc analysis, exporters, etc.).
+ */
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+import yargs, { Arguments } from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { getSchemaFilepaths } from "./Loaders.js";
+import {
+  composeAll,
+  ComposedSchemaJson,
+  RawSchemaJson,
+} from "./SchemaComposer.js";
+
+const SCHEMA_DIR = "schema";
+
+async function readRawSchemas(
+  verbose: boolean
+): Promise<Array<{ relPath: string; json: RawSchemaJson }>> {
+  const filepaths = await getSchemaFilepaths(verbose);
+  return Promise.all(
+    filepaths.map(async (absPath) => {
+      const buf = await readFile(absPath);
+      const json = JSON.parse(buf.toString()) as RawSchemaJson;
+      // getSchemaFilepaths walks from cwd's ./schema, so paths are like
+      // "schema/objects/Foo.schema.json" or absolute — normalize either way.
+      const normalized = path.relative(process.cwd(), absPath);
+      const schemaIndex = normalized.indexOf(SCHEMA_DIR + path.sep);
+      const relPath =
+        schemaIndex >= 0
+          ? normalized.slice(schemaIndex + SCHEMA_DIR.length + 1)
+          : path.basename(absPath);
+      return { relPath, json };
+    })
+  );
+}
+
+async function writeComposedSchema(
+  outDir: string,
+  relPath: string,
+  composed: ComposedSchemaJson,
+  verbose: boolean
+): Promise<void> {
+  const targetPath = path.join(outDir, relPath);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, JSON.stringify(composed, null, 2) + "\n");
+  if (verbose) console.log(`\t• wrote ${targetPath}`);
+}
+
+export async function composeSchemasToDir(
+  outDir: string,
+  verbose: boolean = false
+): Promise<{ written: number }> {
+  await mkdir(outDir, { recursive: true });
+
+  if (verbose) console.log(`\nReading raw schemas from ./${SCHEMA_DIR} ...`);
+  const rawEntries = await readRawSchemas(verbose);
+
+  if (verbose) console.log(`\nComposing ${rawEntries.length} schemas ...`);
+  const { composedById } = composeAll(rawEntries.map((e) => e.json));
+
+  if (verbose) console.log(`\nWriting composed schemas to ${outDir} ...`);
+  let written = 0;
+  for (const { relPath, json } of rawEntries) {
+    const composed = composedById[json.$id];
+    if (!composed) {
+      throw new Error(`Missing composed output for ${json.$id}`);
+    }
+    await writeComposedSchema(outDir, relPath, composed, verbose);
+    written++;
+  }
+
+  console.log(`Composed ${written} schemas into ${outDir}`);
+  return { written };
+}
+
+interface ComposeSchemasArgs extends Arguments {
+  out?: string;
+  o?: string;
+  verbose?: boolean;
+  v?: boolean;
+}
+
+// Only wire up the CLI when this module is the entrypoint (not when
+// imported, e.g. from tests).
+const invokedAsScript =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  process.argv[1].endsWith("ComposeSchemas.ts");
+
+if (invokedAsScript) {
+  yargs(hideBin(process.argv))
+    .command({
+      command: "$0",
+      describe:
+        "Walk /schema, compose each schema (flatten allOf), and write the results into <out>.",
+      builder: {
+        out: {
+          describe:
+            "Target directory. Created if missing. Mirrors the /schema layout.",
+          alias: "o",
+          demandOption: true,
+          type: "string",
+        },
+        verbose: {
+          describe: "Print per-file progress.",
+          alias: "v",
+          demandOption: false,
+          type: "boolean",
+          default: false,
+        },
+      },
+      handler: async (argv: ComposeSchemasArgs) => {
+        const outDir = path.resolve(
+          process.cwd(),
+          (argv.out ?? argv.o) as string
+        );
+        const verbose = Boolean(argv.verbose ?? argv.v);
+        await composeSchemasToDir(outDir, verbose);
+      },
+    })
+    .help()
+    .alias("help", "h").argv;
+}

--- a/utils/schema-utils/SchemaComposer.test.ts
+++ b/utils/schema-utils/SchemaComposer.test.ts
@@ -1,0 +1,216 @@
+import {
+  buildSchemaRegistry,
+  composeAll,
+  composeSchema,
+  isBackwardsCompatibleWrapper,
+  RawSchemaJson,
+} from "./SchemaComposer.js";
+
+const BASE_OBJECT: RawSchemaJson = {
+  $id: "test://base-object",
+  title: "Base",
+  description: "Base object",
+  type: "object",
+  properties: {
+    id: { description: "ID", type: "string" },
+    comments: {
+      description: "Comments",
+      type: "array",
+      items: { type: "string" },
+    },
+    object_type: { $ref: "test://enum-object-type" },
+  },
+  required: ["id", "object_type"],
+};
+
+const TRANSACTION_BASE: RawSchemaJson = {
+  $id: "test://transaction",
+  title: "Transaction",
+  description: "Base transaction",
+  type: "object",
+  properties: {
+    date: { description: "Date", type: "string" },
+  },
+  required: ["date"],
+};
+
+const STOCK_ISSUANCE: RawSchemaJson = {
+  $id: "test://stock-issuance",
+  title: "Stock Issuance",
+  description: "Issuance of stock",
+  type: "object",
+  allOf: [{ $ref: "test://base-object" }, { $ref: "test://transaction" }],
+  properties: {
+    object_type: { const: "TX_STOCK_ISSUANCE" },
+    quantity: { description: "Quantity", type: "string" },
+    id: {}, // placeholder for inheritance
+    date: {}, // placeholder for inheritance
+  },
+  required: ["quantity"],
+};
+
+const WRAPPER: RawSchemaJson = {
+  $id: "test://wrapper",
+  title: "Wrapper",
+  description: "A backwards-compat wrapper",
+  allOf: [{ $ref: "test://stock-issuance" }],
+  properties: {
+    object_type: { const: "TX_STOCK_ISSUANCE_DEPRECATED" },
+  },
+};
+
+describe("SchemaComposer", () => {
+  describe("isBackwardsCompatibleWrapper", () => {
+    it("returns true for a single-allOf, single-property wrapper", () => {
+      expect(isBackwardsCompatibleWrapper(WRAPPER)).toBe(true);
+    });
+
+    it("returns false for a normal object schema with allOf", () => {
+      expect(isBackwardsCompatibleWrapper(STOCK_ISSUANCE)).toBe(false);
+    });
+
+    it("returns false for a schema with no allOf", () => {
+      expect(isBackwardsCompatibleWrapper(BASE_OBJECT)).toBe(false);
+    });
+  });
+
+  describe("buildSchemaRegistry", () => {
+    it("indexes schemas by $id", () => {
+      const reg = buildSchemaRegistry([BASE_OBJECT, TRANSACTION_BASE]);
+      expect(reg["test://base-object"]).toBe(BASE_OBJECT);
+      expect(reg["test://transaction"]).toBe(TRANSACTION_BASE);
+    });
+
+    it("throws on duplicate $id", () => {
+      expect(() =>
+        buildSchemaRegistry([BASE_OBJECT, { ...BASE_OBJECT, title: "Dup" }])
+      ).toThrow(/Duplicate schema/);
+    });
+  });
+
+  describe("composeSchema", () => {
+    it("merges allOf properties in declaration order then own properties", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      const composed = composeSchema(STOCK_ISSUANCE, reg);
+      expect(Object.keys(composed.properties)).toEqual([
+        "id",
+        "comments",
+        "object_type",
+        "date",
+        "quantity",
+      ]);
+    });
+
+    it("lets child own-properties override parent values but keep parent key positions", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      const composed = composeSchema(STOCK_ISSUANCE, reg);
+      expect(composed.properties.object_type).toEqual({
+        const: "TX_STOCK_ISSUANCE",
+      });
+    });
+
+    it("skips placeholder ({}) own-property entries so parent value wins", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      const composed = composeSchema(STOCK_ISSUANCE, reg);
+      expect(composed.properties.id).toEqual({
+        description: "ID",
+        type: "string",
+      });
+      expect(composed.properties.date).toEqual({
+        description: "Date",
+        type: "string",
+      });
+    });
+
+    it("concatenates required from own + every parent (recursive)", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      const composed = composeSchema(STOCK_ISSUANCE, reg);
+      expect(composed.required).toEqual([
+        "quantity",
+        "id",
+        "object_type",
+        "date",
+      ]);
+    });
+
+    it("preserves $id, allOf $refs, and other top-level fields", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      const composed = composeSchema(STOCK_ISSUANCE, reg);
+      expect(composed.$id).toBe(STOCK_ISSUANCE.$id);
+      expect(composed.allOf).toEqual(STOCK_ISSUANCE.allOf);
+      expect(composed.title).toBe(STOCK_ISSUANCE.title);
+      expect(composed.description).toBe(STOCK_ISSUANCE.description);
+    });
+
+    it("returns wrapper schemas unchanged (no flattening of their allOf)", () => {
+      const reg = buildSchemaRegistry([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+        WRAPPER,
+      ]);
+      const composed = composeSchema(WRAPPER, reg);
+      expect(Object.keys(composed.properties)).toEqual(["object_type"]);
+      expect(composed.properties.object_type).toEqual({
+        const: "TX_STOCK_ISSUANCE_DEPRECATED",
+      });
+      expect(composed.allOf).toEqual(WRAPPER.allOf);
+    });
+
+    it("throws when an allOf $ref points at an unknown $id", () => {
+      const orphan: RawSchemaJson = {
+        $id: "test://orphan",
+        allOf: [{ $ref: "test://does-not-exist" }],
+        properties: { x: { const: 1 } },
+      };
+      const reg = buildSchemaRegistry([orphan]);
+      expect(() => composeSchema(orphan, reg)).toThrow(/unknown allOf \$ref/);
+    });
+
+    it("is memoized — composing the same $id twice returns the cached object", () => {
+      const reg = buildSchemaRegistry([BASE_OBJECT]);
+      const cache = new Map();
+      const a = composeSchema(BASE_OBJECT, reg, cache);
+      const b = composeSchema(BASE_OBJECT, reg, cache);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("composeAll", () => {
+    it("returns the registry, the composed list, and an id index", () => {
+      const result = composeAll([
+        BASE_OBJECT,
+        TRANSACTION_BASE,
+        STOCK_ISSUANCE,
+      ]);
+      expect(result.composed).toHaveLength(3);
+      expect(
+        result.composedById[STOCK_ISSUANCE.$id].properties.quantity
+      ).toEqual({
+        description: "Quantity",
+        type: "string",
+      });
+      expect(result.registry[BASE_OBJECT.$id]).toBe(BASE_OBJECT);
+    });
+  });
+});

--- a/utils/schema-utils/SchemaComposer.ts
+++ b/utils/schema-utils/SchemaComposer.ts
@@ -1,0 +1,222 @@
+/**
+ * SchemaComposer
+ *
+ * Walks an OCF schema registry and produces a "composed" view of any schema
+ * by flattening its `allOf` ancestor chain into a single schema with merged
+ * `properties` and `required` arrays. The original `$id`, `allOf` array, and
+ * every other top-level field are preserved as-is so downstream consumers
+ * (e.g. the markdown doc generator) can still render "Composed From" links
+ * or detect backwards-compatibility wrappers.
+ *
+ * The module is intentionally framework-free: it operates on plain JSON
+ * objects and an `$id` -> raw-schema map, so it can be reused outside the
+ * doc generator (validation tooling, downstream codegen, etc.).
+ */
+
+export type RawSchemaJson = {
+  $id: string;
+  title?: string;
+  description?: string;
+  type?: string;
+  allOf?: Array<{ $ref: string }>;
+  properties?: { [name: string]: any };
+  required?: string[];
+  [extra: string]: any;
+};
+
+export type ComposedSchemaJson = RawSchemaJson & {
+  properties: { [name: string]: any };
+  required: string[];
+};
+
+export type SchemaRegistry = { [id: string]: RawSchemaJson };
+
+/**
+ * A schema is a backwards-compatibility wrapper if it declares a single
+ * `allOf` entry, a single `properties.object_type` field, and nothing else
+ * of substance. These wrappers must NOT be flattened: they intentionally
+ * stand alone as an alias for another, fully-defined object schema.
+ *
+ * The detection logic mirrors `isBackwardsCompatibleJson` in
+ * `utils/generate-docs/Schema/SchemaNode/Factory.ts` so both call sites
+ * agree on what counts as a wrapper.
+ */
+export function isBackwardsCompatibleWrapper(
+  json: RawSchemaJson | undefined | null
+): boolean {
+  if (!json || typeof json !== "object") return false;
+
+  const properties = json.properties;
+  if (!properties || typeof properties !== "object") return false;
+
+  const keys = Object.keys(properties);
+  if (keys.length !== 1) return false;
+
+  const objectType = (properties as Record<string, unknown>).object_type;
+  if (!objectType || typeof objectType !== "object") return false;
+
+  const allOf = json.allOf;
+  if (!Array.isArray(allOf) || allOf.length !== 1) return false;
+
+  const ref = allOf[0]?.$ref;
+  return typeof ref === "string";
+}
+
+/**
+ * Build an $id -> raw-schema map from a flat list of raw schema JSONs.
+ * Throws if two schemas share an `$id`, because that would make composition
+ * ambiguous.
+ */
+export function buildSchemaRegistry(
+  rawSchemas: RawSchemaJson[]
+): SchemaRegistry {
+  const registry: SchemaRegistry = {};
+  for (const json of rawSchemas) {
+    if (!json || typeof json !== "object" || typeof json.$id !== "string") {
+      continue;
+    }
+    if (registry[json.$id]) {
+      throw new Error(`Duplicate schema $id in registry: ${json.$id}`);
+    }
+    registry[json.$id] = json;
+  }
+  return registry;
+}
+
+/**
+ * Compose a single schema by flattening its `allOf` chain.
+ *
+ * Merge semantics (chosen to be a behavior-preserving extraction of the
+ * doc-generator's previous in-class logic):
+ *
+ *   - Wrapper schemas are returned unchanged (only `properties` and
+ *     `required` are defaulted to {} / []).
+ *   - For non-wrappers, each entry in `allOf` is composed first (recursively,
+ *     memoized via `cache`). The composed parents' `properties` are spread
+ *     in declaration order; then the schema's own `properties` are applied
+ *     on top, with entries whose value is an empty object (placeholders that
+ *     opt into inheriting from the parent) skipped so they do not overwrite
+ *     a parent's definition. Key ORDER is preserved: parents' keys keep
+ *     their original positions even when the child overrides their values.
+ *   - `required` is the concatenation of the schema's own `required` and
+ *     every composed parent's `required` (recursive). Duplicates are
+ *     intentionally kept to match the pre-extraction behavior.
+ */
+export function composeSchema(
+  rawJson: RawSchemaJson,
+  registry: SchemaRegistry,
+  cache: Map<string, ComposedSchemaJson> = new Map()
+): ComposedSchemaJson {
+  const cached = cache.get(rawJson.$id);
+  if (cached) return cached;
+
+  if (isBackwardsCompatibleWrapper(rawJson)) {
+    const wrapper: ComposedSchemaJson = {
+      ...rawJson,
+      properties: rawJson.properties ?? {},
+      required: rawJson.required ? [...rawJson.required] : [],
+    };
+    cache.set(rawJson.$id, wrapper);
+    return wrapper;
+  }
+
+  const allOf = rawJson.allOf ?? [];
+  const parents: ComposedSchemaJson[] = allOf.map((ref) => {
+    const parentRaw = registry[ref.$ref];
+    if (!parentRaw) {
+      throw new Error(
+        `Cannot compose ${rawJson.$id}: unknown allOf $ref '${ref.$ref}'`
+      );
+    }
+    return composeSchema(parentRaw, registry, cache);
+  });
+
+  const mergedProperties: { [name: string]: any } = {};
+  for (const parent of parents) {
+    Object.assign(mergedProperties, parent.properties ?? {});
+  }
+  for (const [name, value] of Object.entries(rawJson.properties ?? {})) {
+    const isPlaceholder =
+      value && typeof value === "object" && Object.keys(value).length === 0;
+    if (!isPlaceholder) {
+      mergedProperties[name] = value;
+    }
+  }
+
+  const required: string[] = [
+    ...(rawJson.required ?? []),
+    ...parents.flatMap((parent) => parent.required ?? []),
+  ];
+
+  const composed: ComposedSchemaJson = {
+    ...rawJson,
+    properties: mergedProperties,
+    required,
+  };
+  cache.set(rawJson.$id, composed);
+  return composed;
+}
+
+export type ComposeAllOptions = {
+  /**
+   * Behavior when an `allOf` `$ref` cannot be resolved in the registry:
+   *  - `"throw"` (default): propagate the error from `composeSchema`. Use
+   *    this for production runs and external utilities — a dangling `$ref`
+   *    is a real schema bug and should fail loudly.
+   *  - `"skip"`: fall back to the raw schema (with `properties`/`required`
+   *    defaulted) for any schema whose composition fails because of a
+   *    missing parent. This preserves the doc-generator's historical
+   *    lazy-resolution semantics, where missing refs only surfaced if the
+   *    consumer actually walked the `allOf` chain (e.g. when rendering
+   *    properties). Used by the doc generator so partial test fixtures
+   *    don't break.
+   */
+  onMissingRef?: "throw" | "skip";
+};
+
+const missingRefMessage = "unknown allOf $ref";
+
+function fallbackComposed(raw: RawSchemaJson): ComposedSchemaJson {
+  return {
+    ...raw,
+    properties: raw.properties ?? {},
+    required: raw.required ? [...raw.required] : [],
+  };
+}
+
+/**
+ * Compose every schema in `rawSchemas` and return both the registry of raw
+ * schemas and the parallel registry of composed schemas (keyed by `$id`),
+ * plus the composed list in the same order as the input. Useful for callers
+ * (the doc generator, external utilities) that want one pass over the full
+ * schema tree.
+ */
+export function composeAll(
+  rawSchemas: RawSchemaJson[],
+  options: ComposeAllOptions = {}
+): {
+  registry: SchemaRegistry;
+  composed: ComposedSchemaJson[];
+  composedById: { [id: string]: ComposedSchemaJson };
+} {
+  const { onMissingRef = "throw" } = options;
+  const registry = buildSchemaRegistry(rawSchemas);
+  const cache = new Map<string, ComposedSchemaJson>();
+  const composed = rawSchemas.map((raw) => {
+    try {
+      return composeSchema(raw, registry, cache);
+    } catch (err) {
+      const isMissingRef =
+        err instanceof Error && err.message.includes(missingRefMessage);
+      if (onMissingRef === "skip" && isMissingRef) {
+        const fb = fallbackComposed(raw);
+        cache.set(raw.$id, fb);
+        return fb;
+      }
+      throw err;
+    }
+  });
+  const composedById: { [id: string]: ComposedSchemaJson } = {};
+  for (const c of composed) composedById[c.$id] = c;
+  return { registry, composed, composedById };
+}


### PR DESCRIPTION
## Summary

- Pulls `allOf`-chain flattening out of the doc-generator's `SchemaNode` classes into a new framework-free module: `utils/schema-utils/SchemaComposer.ts`. Exports `composeSchema`, `composeAll`, `buildSchemaRegistry`, and `isBackwardsCompatibleWrapper`.
- The doc generator's `Schema` constructor now invokes `composeAll(rawJsons, { onMissingRef: "skip" })` before building `SchemaNode`s, so each node sees an already-flattened JSON. `SchemaNode.properties()` and `required()` become straight reads; `allOf()` is retained for "Composed From" link rendering. The wrapper class loses its dead overrides because wrapper-detection now lives in the composer.
- New `npm run schema:compose -- --out <dir>` CLI (`utils/schema-utils/ComposeSchemas.ts`) walks `/schema`, composes every file, and writes the full registry to `<dir>` mirroring the source layout. The target directory (including missing parents) is created on demand.

## Behavior preservation

- `diff -r <pre-change-docs> docs/schema_markdown` is **empty** — every byte of the 176 generated markdown files is identical to `main`. The `check-gen-docs` CI job will pass without any commit to `docs/schema_markdown`.
- Wrapper schemas (e.g. `objects/transactions/cancellation/PlanSecurityCancellation`) pass through the composer untouched, matching the previous renderer's behavior.
- A composed top-level object (e.g. `StockConversion`) now exposes every inherited property at the parent's position, with the child's own values winning on overrides and child-side `{}` placeholders deferring to the parent — exact replication of the prior in-class merge logic.

## Test plan

- [x] `npm test` — 15 suites, 38 tests pass (14 new tests in `utils/schema-utils/SchemaComposer.test.ts` cover wrapper detection, registry building, property/required merging, key-order preservation, placeholder fallback, missing-ref errors, and memoization)
- [x] `npm run docs:generate` — output identical to `main`'s `docs/schema_markdown` (verified with `diff -r`)
- [x] `npm run schema:validate-ocf-file-schemas` — all schemas valid
- [x] `npm run schema:compose -- --out /tmp/ocf-composed` — writes 175 composed schemas (175 source files in `/schema`)
- [x] `npm run schema:compose -- --out /tmp/nested/missing/dir` — creates nested target directory on demand
- [x] `npm run schema:compose -- --help` — prints usage; missing `--out` errors with `Missing required argument: out`