### PR TITLE
Emit aggregate discriminated-union types from the schema codegen

### DIFF
--- a/utils/schema-utils/TypeScriptGenerator.integration.test.ts
+++ b/utils/schema-utils/TypeScriptGenerator.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, beforeAll } from "@jest/globals";
+import { readFile } from "node:fs/promises";
+
+import { getSchemaFilepaths } from "./Loaders.js";
+import { generateTypeScript } from "./TypeScriptGenerator.js";
+import type { RawSchemaJson } from "./SchemaComposer.js";
+
+// Integration coverage over the *real* /schema tree (the synthetic-fixture unit
+// tests in TypeScriptGenerator.test.ts can't catch a real-schema regression: a
+// new transaction missed by AnyTransaction, a wrapper leaking into a union, or
+// an object_type / enum drift). These pin the headline aggregate counts and —
+// the load-bearing one — assert the discriminant maps are EXACTLY the generated
+// discriminant enums, so the "provably exhaustive" property fails CI on drift
+// instead of silently holding by coincidence.
+
+const mapKeysOf = (src: string, name: string): string[] => {
+  const m = src.match(
+    new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`)
+  );
+  return m
+    ? [...m[1].matchAll(/^\s+("?[\w]+"?):/gm)].map((x) =>
+        x[1].replace(/"/g, "")
+      )
+    : [];
+};
+const unionMembersOf = (src: string, name: string): string[] => {
+  const m = src.match(new RegExp(`export type ${name} =\\n([\\s\\S]*?);`));
+  return m
+    ? [...m[1].matchAll(/^\s+\|\s+(.+?)\s*$/gm)].map((x) =>
+        x[1].replace(/"/g, "")
+      )
+    : [];
+};
+/** The value type names in `export interface <name> { k: V; … }`. */
+const mapValuesOf = (src: string, name: string): string[] => {
+  const m = src.match(
+    new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`)
+  );
+  return m ? [...m[1].matchAll(/:\s+(\w+);/g)].map((x) => x[1]) : [];
+};
+
+describe("aggregate generation over the real /schema tree", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    const paths = await getSchemaFilepaths();
+    const raw: RawSchemaJson[] = await Promise.all(
+      paths.map(
+        async (p) => JSON.parse(await readFile(p, "utf8")) as RawSchemaJson
+      )
+    );
+    source = generateTypeScript(raw).source;
+  });
+
+  it("pins the aggregate counts (guards against silent drift)", () => {
+    // INTENTIONAL TRIPWIRE: these exact counts are meant to fail when the schema
+    // set changes. On a deliberate schema add/remove, bump them in the same PR —
+    // the failure is the prompt to confirm the aggregates moved as expected. The
+    // relationship invariants below are what hold without per-schema churn.
+    expect(unionMembersOf(source, "AnyObject")).toHaveLength(49);
+    expect(unionMembersOf(source, "AnyTransaction")).toHaveLength(40);
+    expect(unionMembersOf(source, "AnyFile")).toHaveLength(10);
+    expect(mapKeysOf(source, "ObjectTypeMap")).toHaveLength(56);
+    expect(mapKeysOf(source, "FileTypeMap")).toHaveLength(10);
+  });
+
+  it("ObjectTypeMap keys are EXACTLY the OCFObjectType members (provably exhaustive)", () => {
+    // This is the invariant the many-to-one design exists to guarantee:
+    // keyof ObjectTypeMap covers every object_type a package can carry.
+    expect(new Set(mapKeysOf(source, "ObjectTypeMap"))).toEqual(
+      new Set(unionMembersOf(source, "OCFObjectType"))
+    );
+  });
+
+  it("FileTypeMap keys are EXACTLY the OCFFileType members", () => {
+    expect(new Set(mapKeysOf(source, "FileTypeMap"))).toEqual(
+      new Set(unionMembersOf(source, "OCFFileType"))
+    );
+  });
+
+  it("unions exclude the back-compat wrapper aliases", () => {
+    const tx = unionMembersOf(source, "AnyTransaction");
+    // Wrappers (OCFPlanSecurity*) are subtypes of their parent — absorbed by the
+    // union, so they must not be listed; the parent must be.
+    expect(tx.some((m) => m.startsWith("OCFPlanSecurity"))).toBe(false);
+    expect(tx).toContain("OCFEquityCompensationIssuance");
+  });
+
+  // Churn-free relationship invariants (hold across schema evolution without
+  // touching magic numbers) — complementing the pinned counts above.
+  it("AnyTransaction is a subset of AnyObject", () => {
+    const objects = new Set(unionMembersOf(source, "AnyObject"));
+    for (const t of unionMembersOf(source, "AnyTransaction")) {
+      expect(objects.has(t)).toBe(true);
+    }
+  });
+
+  it("union members and map values are non-empty, unique, and reference declared types", () => {
+    const declared = new Set(
+      [...source.matchAll(/^export (?:interface|type) (\w+)/gm)].map(
+        (m) => m[1]
+      )
+    );
+    for (const u of ["AnyObject", "AnyTransaction", "AnyFile"]) {
+      const members = unionMembersOf(source, u);
+      expect(members.length).toBeGreaterThan(0);
+      expect(new Set(members).size).toBe(members.length); // no duplicates
+      for (const m of members) expect(declared.has(m)).toBe(true);
+    }
+    for (const map of ["ObjectTypeMap", "FileTypeMap"]) {
+      const values = mapValuesOf(source, map);
+      expect(values.length).toBeGreaterThan(0);
+      for (const v of values) expect(declared.has(v)).toBe(true);
+    }
+  });
+});

--- a/utils/schema-utils/TypeScriptGenerator.test.ts
+++ b/utils/schema-utils/TypeScriptGenerator.test.ts
@@ -92,6 +92,84 @@ const ALL = [
   OBJECT_ISSUER,
 ];
 
+// --- Aggregate fixtures: a transaction object with a back-compat `enum`
+// discriminant, its narrowed legacy wrapper, and a file wrapper. ---
+const TX_EQUITY_ISSUANCE: RawSchemaJson = {
+  $id: `${BASE}/objects/transactions/issuance/EquityCompensationIssuance.schema.json`,
+  title: "Object - Equity Compensation Issuance",
+  type: "object",
+  allOf: [{ $ref: PRIMITIVE_OBJECT.$id }],
+  // More than just `object_type` so this is a real interface, not a
+  // back-compat wrapper (the wrapper predicate keys on a lone object_type).
+  properties: {
+    object_type: {
+      enum: ["TX_PLAN_SECURITY_ISSUANCE", "TX_EQUITY_COMPENSATION_ISSUANCE"],
+    },
+    quantity: { $ref: TYPE_NUMERIC.$id },
+  },
+  required: ["object_type", "quantity"],
+};
+
+const TX_PLAN_ISSUANCE_WRAPPER: RawSchemaJson = {
+  $id: `${BASE}/objects/transactions/issuance/PlanSecurityIssuance.schema.json`,
+  title: "Object - Plan Security Issuance",
+  allOf: [{ $ref: TX_EQUITY_ISSUANCE.$id }],
+  properties: {
+    object_type: {
+      const: "TX_PLAN_SECURITY_ISSUANCE",
+      description: "Deprecated in v2.0.0",
+    },
+  },
+};
+
+const FILE_TRANSACTIONS: RawSchemaJson = {
+  $id: `${BASE}/files/TransactionsFile.schema.json`,
+  title: "File - Transactions",
+  type: "object",
+  properties: {
+    file_type: { const: "OCF_TRANSACTIONS_FILE" },
+    items: { type: "array", items: { $ref: TX_EQUITY_ISSUANCE.$id } },
+  },
+  required: ["file_type", "items"],
+};
+
+const AGG_INPUTS = [
+  ENUM_OBJECT_TYPE,
+  TYPE_DATE,
+  TYPE_NUMERIC,
+  PRIMITIVE_OBJECT,
+  OBJECT_ISSUER,
+  TX_EQUITY_ISSUANCE,
+  TX_PLAN_ISSUANCE_WRAPPER,
+  FILE_TRANSACTIONS,
+];
+
+/** Names of every top-level `export interface|type` declaration in a module. */
+const exportedNames = (src: string): string[] =>
+  [...src.matchAll(/^export (?:interface|type) (\w+)/gm)].map((m) => m[1]);
+
+/** The keys declared in `export interface <name> { … }` (quotes stripped). */
+const mapKeysOf = (src: string, name: string): string[] => {
+  const m = src.match(
+    new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`)
+  );
+  return m
+    ? [...m[1].matchAll(/^\s+("?[\w]+"?):/gm)].map((x) =>
+        x[1].replace(/"/g, "")
+      )
+    : [];
+};
+
+/** The members of an `export type <name> =\n  | A\n  | B;` union (quotes stripped). */
+const unionMembersOf = (src: string, name: string): string[] => {
+  const m = src.match(new RegExp(`export type ${name} =\\n([\\s\\S]*?);`));
+  return m
+    ? [...m[1].matchAll(/^\s+\|\s+(.+?)\s*$/gm)].map((x) =>
+        x[1].replace(/"/g, "")
+      )
+    : [];
+};
+
 describe("TypeScriptGenerator", () => {
   describe("generateTypeScript", () => {
     const { source, typeNames, warnings } = generateTypeScript(ALL);
@@ -306,6 +384,185 @@ describe("TypeScriptGenerator", () => {
       expect(typeNames[PRIMITIVE_OBJECT.$id]).toBe("OCFObject");
       expect(source).toContain("export interface OCFObject {");
       expect(source).toContain("// Primitives");
+    });
+  });
+
+  describe("aggregates", () => {
+    const { source } = generateTypeScript(AGG_INPUTS);
+
+    it("emits all five aggregate declarations", () => {
+      expect(source).toContain("// Aggregates");
+      expect(source).toContain("export type AnyObject =");
+      expect(source).toContain("export type AnyTransaction =");
+      expect(source).toContain("export type AnyFile =");
+      expect(source).toContain("export interface ObjectTypeMap {");
+      expect(source).toContain("export interface FileTypeMap {");
+    });
+
+    it("unions list concrete types and exclude back-compat wrappers", () => {
+      const any = source.slice(
+        source.indexOf("export type AnyObject ="),
+        source.indexOf("export type AnyTransaction =")
+      );
+      expect(any).toContain("| OCFIssuer");
+      expect(any).toContain("| OCFEquityCompensationIssuance");
+      // The wrapper is a subtype of its parent, so the union must not list it.
+      expect(any).not.toContain("OCFPlanSecurityIssuance");
+    });
+
+    it("AnyTransaction holds transactions only (not plain objects)", () => {
+      const tx = source.slice(
+        source.indexOf("export type AnyTransaction ="),
+        source.indexOf("export type AnyFile =")
+      );
+      expect(tx).toContain("| OCFEquityCompensationIssuance");
+      expect(tx).not.toContain("OCFIssuer"); // non-transaction object
+      expect(tx).not.toContain("OCFPlanSecurityIssuance"); // wrapper
+    });
+
+    it("AnyFile holds file wrappers", () => {
+      const files = source.slice(
+        source.indexOf("export type AnyFile ="),
+        source.indexOf("export interface ObjectTypeMap {")
+      );
+      expect(files).toContain("| OCFTransactionsFile");
+    });
+
+    it("ObjectTypeMap keys every object_type, legacy value to its narrowed wrapper", () => {
+      const map = source.slice(
+        source.indexOf("export interface ObjectTypeMap {"),
+        source.indexOf("export interface FileTypeMap {")
+      );
+      expect(map).toContain("ISSUER: OCFIssuer;");
+      expect(map).toContain(
+        "TX_EQUITY_COMPENSATION_ISSUANCE: OCFEquityCompensationIssuance;"
+      );
+      // The legacy value resolves to the precise wrapper, not the parent.
+      expect(map).toContain(
+        "TX_PLAN_SECURITY_ISSUANCE: OCFPlanSecurityIssuance;"
+      );
+    });
+
+    it("ObjectTypeMap key set is exactly the input object_types (no missing/extra)", () => {
+      // Exact set, not spot-checks: an added/dropped/misspelled key fails here.
+      expect(new Set(mapKeysOf(source, "ObjectTypeMap"))).toEqual(
+        new Set([
+          "ISSUER",
+          "TX_PLAN_SECURITY_ISSUANCE",
+          "TX_EQUITY_COMPENSATION_ISSUANCE",
+        ])
+      );
+    });
+
+    it("FileTypeMap keys each file_type to its wrapper", () => {
+      const map = source.slice(
+        source.indexOf("export interface FileTypeMap {")
+      );
+      expect(map).toContain("OCF_TRANSACTIONS_FILE: OCFTransactionsFile;");
+    });
+
+    it("census: exactly one export per emitted schema, plus the five aggregates", () => {
+      const names = exportedNames(source);
+      // 8 inputs, primitive base omitted -> 7 per-schema declarations.
+      const perSchema = [
+        "OCFObjectType",
+        "OCFDate",
+        "OCFNumeric",
+        "OCFIssuer",
+        "OCFEquityCompensationIssuance",
+        "OCFPlanSecurityIssuance",
+        "OCFTransactionsFile",
+      ];
+      const aggregates = [
+        "AnyObject",
+        "AnyTransaction",
+        "AnyFile",
+        "ObjectTypeMap",
+        "FileTypeMap",
+      ];
+      expect(new Set(names)).toEqual(new Set([...perSchema, ...aggregates]));
+      expect(names).toHaveLength(perSchema.length + aggregates.length);
+    });
+
+    it("throws when two non-wrapper schemas claim the same object_type", () => {
+      const a: RawSchemaJson = {
+        $id: `${BASE}/objects/Alpha.schema.json`,
+        type: "object",
+        properties: { object_type: { const: "DUP" } },
+      };
+      const b: RawSchemaJson = {
+        $id: `${BASE}/objects/Bravo.schema.json`,
+        type: "object",
+        properties: { object_type: { const: "DUP" } },
+      };
+      expect(() => generateTypeScript([a, b])).toThrow(
+        /Multiple schemas claim object_type "DUP"/
+      );
+    });
+
+    it("throws when two non-wrapper schemas claim the same file_type", () => {
+      const a: RawSchemaJson = {
+        $id: `${BASE}/files/AlphaFile.schema.json`,
+        type: "object",
+        properties: { file_type: { const: "OCF_DUP_FILE" } },
+      };
+      const b: RawSchemaJson = {
+        $id: `${BASE}/files/BravoFile.schema.json`,
+        type: "object",
+        properties: { file_type: { const: "OCF_DUP_FILE" } },
+      };
+      expect(() => generateTypeScript([a, b])).toThrow(
+        /Multiple schemas claim file_type "OCF_DUP_FILE"/
+      );
+    });
+
+    it("throws when two back-compat wrappers claim the same object_type", () => {
+      const parent: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/EquityCompensationIssuance.schema.json`,
+        type: "object",
+        properties: {
+          object_type: { enum: ["DUP", "TX_EQUITY_COMPENSATION_ISSUANCE"] },
+          quantity: { type: "string" },
+        },
+        required: ["object_type", "quantity"],
+      };
+      const wrapperA: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/WrapperA.schema.json`,
+        allOf: [{ $ref: parent.$id }],
+        properties: { object_type: { const: "DUP" } },
+      };
+      const wrapperB: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/WrapperB.schema.json`,
+        allOf: [{ $ref: parent.$id }],
+        properties: { object_type: { const: "DUP" } },
+      };
+      expect(() => generateTypeScript([parent, wrapperA, wrapperB])).toThrow(
+        /Multiple wrapper schemas claim object_type "DUP"/
+      );
+    });
+
+    it("throws on duplicate non-wrapper claims even when a wrapper also claims the value", () => {
+      // A lone wrapper must not mask a genuine non-wrapper collision.
+      const concreteA: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/ConcreteA.schema.json`,
+        type: "object",
+        properties: { object_type: { const: "DUP" }, x: { type: "string" } },
+        required: ["object_type", "x"],
+      };
+      const concreteB: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/ConcreteB.schema.json`,
+        type: "object",
+        properties: { object_type: { const: "DUP" }, y: { type: "string" } },
+        required: ["object_type", "y"],
+      };
+      const wrapper: RawSchemaJson = {
+        $id: `${BASE}/objects/transactions/issuance/WrapperC.schema.json`,
+        allOf: [{ $ref: concreteA.$id }],
+        properties: { object_type: { const: "DUP" } },
+      };
+      expect(() => generateTypeScript([concreteA, concreteB, wrapper])).toThrow(
+        /Multiple schemas claim object_type "DUP"/
+      );
     });
 
     it("warns (not silently dangles) on a direct $ref to an omitted primitive", () => {

--- a/utils/schema-utils/TypeScriptGenerator.ts
+++ b/utils/schema-utils/TypeScriptGenerator.ts
@@ -131,6 +131,29 @@ function categoryPriority(id: string): number {
   return idx === -1 ? CATEGORY_ORDER.length : idx;
 }
 
+/** Transaction object schemas live under `/schema/objects/transactions/`. Used
+ *  to split the `objects` partition into `AnyTransaction` vs the rest. */
+function isTransactionId(id: string): boolean {
+  return id.includes("/objects/transactions/");
+}
+
+/** The literal string value(s) of a discriminant property (`object_type` /
+ *  `file_type`) on a composed schema: handles `const` (one value) and inline
+ *  `enum` (the back-compat case, where a concrete type accepts both its legacy
+ *  and current `object_type`). Returns `[]` when there is no such discriminant. */
+function discriminantLiterals(
+  schema: ComposedSchemaJson,
+  key: string
+): string[] {
+  const prop = (schema.properties as any)?.[key];
+  if (!prop || typeof prop !== "object") return [];
+  if ("const" in prop && typeof prop.const === "string") return [prop.const];
+  if (Array.isArray(prop.enum)) {
+    return prop.enum.filter((v: any): v is string => typeof v === "string");
+  }
+  return [];
+}
+
 function toPascalCase(value: string): string {
   const cleaned = value
     .replace(/[^A-Za-z0-9]+(.)?/g, (_m, c) => (c ? c.toUpperCase() : ""))
@@ -359,14 +382,26 @@ function annotationTags(value: any): string[] {
 // Declarations
 // ---------------------------------------------------------------------------
 
-function declareEnum(name: string, schema: ComposedSchemaJson): string {
-  const members = (schema.enum as any[]).map((member) =>
-    JSON.stringify(member)
-  );
-  const union = members.length
+/** A `=`-bordered section banner — the rule-band placed between output sections. */
+function sectionHeading(title: string): string {
+  const rule = "=".repeat(73);
+  return `// ${rule}\n// ${title}\n// ${rule}`;
+}
+
+/** Render `export type Name =\n  | A\n  | B;` (or `never` when empty). Shared by
+ *  the enum declarer and the aggregate unions; `members` are emitted verbatim. */
+function unionType(name: string, members: string[], doc = ""): string {
+  const body = members.length
     ? members.map((m) => `  | ${m}`).join("\n")
     : "  never";
-  return `export type ${name} =\n${union};`;
+  return `${doc}export type ${name} =\n${body};`;
+}
+
+function declareEnum(name: string, schema: ComposedSchemaJson): string {
+  return unionType(
+    name,
+    (schema.enum as any[]).map((member) => JSON.stringify(member))
+  );
 }
 
 function declareInterface(
@@ -562,11 +597,140 @@ export function generateTypeScript(
     const declarations = byCategory.get(category);
     if (!declarations || !declarations.length) continue;
     declarations.sort((a, b) => declaredName(a).localeCompare(declaredName(b)));
-    const heading = `// ${"=".repeat(73)}\n// ${
-      CATEGORY_HEADINGS[category]
-    }\n// ${"=".repeat(73)}`;
+    const heading = sectionHeading(CATEGORY_HEADINGS[category]);
     sections.push(`${heading}\n\n${declarations.join("\n\n")}`);
   }
+
+  // ----- Aggregates: unions + discriminant maps over the emitted schemas -----
+  // `AnyObject` / `AnyTransaction` / `AnyFile` are unions of the *concrete*
+  // types; the back-compat wrapper aliases are deliberately excluded because
+  // each is a subtype of its parent (e.g. `OCFPlanSecurityIssuance extends
+  // OCFEquityCompensationIssuance`) and would be absorbed by the union anyway.
+  // `ObjectTypeMap` / `FileTypeMap` go the other way: they key every
+  // discriminant value — including the legacy back-compat values — to its most
+  // specific concrete type, so a `keyof`-driven dispatch table is exhaustive
+  // over every value a real package can carry.
+  type Claim = { name: string; wrapper: boolean };
+  const objectMembers: string[] = [];
+  const txMembers: string[] = [];
+  const fileMembers: string[] = [];
+  const objectTypeClaims = new Map<string, Claim[]>();
+  const fileTypeClaims = new Map<string, Claim[]>();
+  const addClaim = (m: Map<string, Claim[]>, lit: string, c: Claim) => {
+    if (!m.has(lit)) m.set(lit, []);
+    m.get(lit)!.push(c);
+  };
+
+  for (const schema of composed) {
+    if (omittedIds.has(schema.$id)) continue;
+    const name = idToName.get(schema.$id);
+    if (!name) continue;
+    const wrapper = isBackwardsCompatibleWrapper(schema);
+    const category = categoryFromId(schema.$id);
+
+    if (category === "objects") {
+      if (!wrapper) {
+        objectMembers.push(name);
+        if (isTransactionId(schema.$id)) txMembers.push(name);
+      }
+      for (const lit of discriminantLiterals(schema, "object_type")) {
+        addClaim(objectTypeClaims, lit, { name, wrapper });
+      }
+    } else if (category === "files") {
+      if (!wrapper) fileMembers.push(name);
+      for (const lit of discriminantLiterals(schema, "file_type")) {
+        addClaim(fileTypeClaims, lit, { name, wrapper });
+      }
+    }
+  }
+
+  // Resolve each discriminant value to one concrete type. A wrapper (the
+  // narrowed legacy alias) wins over its parent on a shared value — that is the
+  // whole point of the wrapper. Two *non-wrapper* schemas claiming the same
+  // value is a genuine schema bug, so fail loudly.
+  const resolveMap = (
+    claims: Map<string, Claim[]>,
+    kind: string
+  ): Array<[string, string]> => {
+    const entries: Array<[string, string]> = [];
+    for (const [literal, list] of claims) {
+      const wrappers = list.filter((c) => c.wrapper);
+      const concrete = list.filter((c) => !c.wrapper);
+      // Check each kind of duplicate independently, so a wrapper's presence can
+      // never mask a genuine non-wrapper collision.
+      if (concrete.length > 1)
+        throw new Error(
+          `Multiple schemas claim ${kind} "${literal}": ${concrete
+            .map((c) => c.name)
+            .join(", ")}`
+        );
+      if (wrappers.length > 1)
+        throw new Error(
+          `Multiple wrapper schemas claim ${kind} "${literal}": ${wrappers
+            .map((c) => c.name)
+            .join(", ")}`
+        );
+      // A wrapper (the narrowed legacy alias) wins over its parent on a shared
+      // value; otherwise the lone concrete type claims it.
+      const chosen =
+        wrappers.length === 1 ? wrappers[0].name : concrete[0].name;
+      entries.push([literal, chosen]);
+    }
+    return entries.sort((a, b) => a[0].localeCompare(b[0]));
+  };
+
+  const aggregateDoc = (text: string) =>
+    includeDescriptions ? jsdoc([text], "") : "";
+  const unionDecl = (name: string, members: string[], doc: string) =>
+    unionType(
+      name,
+      [...new Set(members)].sort((a, b) => a.localeCompare(b)),
+      doc
+    );
+  const mapDecl = (
+    name: string,
+    entries: Array<[string, string]>,
+    doc: string
+  ) => {
+    const body = entries
+      .map(([lit, type]) => `  ${propertyKey(lit)}: ${type};`)
+      .join("\n");
+    return `${doc}export interface ${name} {\n${body}\n}`;
+  };
+
+  const aggregateHeading = sectionHeading(
+    "Aggregates (unions + discriminant maps)"
+  );
+  const aggregateSection = `${aggregateHeading}\n\n${[
+    unionDecl(
+      "AnyObject",
+      objectMembers,
+      aggregateDoc("Union of every concrete OCF object (all `object_type`s).")
+    ),
+    unionDecl(
+      "AnyTransaction",
+      txMembers,
+      aggregateDoc("Union of every concrete OCF transaction object.")
+    ),
+    unionDecl(
+      "AnyFile",
+      fileMembers,
+      aggregateDoc("Union of every OCF file wrapper.")
+    ),
+    mapDecl(
+      "ObjectTypeMap",
+      resolveMap(objectTypeClaims, "object_type"),
+      aggregateDoc(
+        "Maps each `object_type` value — legacy back-compat values included — to its most specific concrete type. `keyof ObjectTypeMap` is exhaustive over every value a package can carry."
+      )
+    ),
+    mapDecl(
+      "FileTypeMap",
+      resolveMap(fileTypeClaims, "file_type"),
+      aggregateDoc("Maps each `file_type` value to its file-wrapper type.")
+    ),
+  ].join("\n\n")}`;
+  sections.push(aggregateSection);
 
   // A caller-supplied banner is used verbatim (pass "" to suppress); otherwise
   // the default banner gets the primitives-policy notice appended.


### PR DESCRIPTION
Stacked on #581 (base `JSv4/schema-toolkit`); it will retarget to `main` once #581 lands.

## Why

This implements the aggregate types I floated in my review of #581: `AnyObject` / `AnyTransaction` / `AnyFile`, and the `ObjectTypeMap` / `FileTypeMap` discriminant lookups.

This is the piece that unblocks the OCF-Tools roadmap. Phase 2 there needs `AnyTransaction` as the XState machine's event type. Phase 3 needs `ObjectTypeMap` so a data-driven handler table is exhaustive over every `object_type` at compile time. Without these living in the schema repo as the single source of truth, OCF-Tools has to rebuild the unions and the discriminant lookup by hand and police them against drift.

**No pride of authorship here.** If anyone would rather shape these differently or use a different way to compute the maps I'm happy to redo it. Mostly just trying to get OCF-Tools roadmap unblocked.

## What's here

Five aggregates, computed from the same schema registry the per-schema types come from (so they can't drift from it):

- `AnyObject` / `AnyTransaction` / `AnyFile` — unions of the concrete types. The back-compat wrapper aliases (`PlanSecurity*`) are excluded: each is a subtype of its parent and would be absorbed by the union anyway.
- `ObjectTypeMap` / `FileTypeMap` — map every discriminant value, including the legacy back-compat values, to its most specific concrete type. On a shared value the narrowed wrapper wins over its parent (`TX_PLAN_SECURITY_ISSUANCE → OCFPlanSecurityIssuance`, current `TX_EQUITY_COMPENSATION_ISSUANCE → OCFEquityCompensationIssuance`). Two non-wrapper schemas claiming one value is a schema bug, so it throws.

The many-to-one map lets a downstream `keyof`-driven dispatch table cover every `object_type` a real package can carry, legacy values included.

Tests: unit coverage of the union / map / wrapper-precedence behavior and the throw paths. Plus a real-`/schema` integration test that pins the aggregate counts and asserts the map keys are exactly the generated `OCFObjectType` / `OCFFileType` members. So the exhaustiveness property fails CI on drift rather than holding by coincidence. The generated module compiles under `tsc --strict`.

## How OCF-Tools uses these in the interim

OCF-Tools uses a deliberately throwaway transport in order to use these types now, before this and #581 merge, and before an npm package exists:

1. It generates `index.d.ts` from this branch and vendors the file, then a tsconfig `paths` alias maps the **final** package specifier `@opencaptablecoalition/ocf-types` to the vendored copy. Call sites import the final specifier today.
2. The transition then costs nothing at the call sites. Once this + #581 land, regenerate from `main`, and once the GitHub Release tarball exists, `npm i` it and delete the alias + vendored file. Once it's on npm, it's a normal dependency. Only that one vendored file and the alias ever change.
