### PR TITLE
Add --experimental flag to resolve version dispatchers (none/compatibility/unstable)

### DIFF
--- a/docs/explainers/DesignPatterns.md
+++ b/docs/explainers/DesignPatterns.md
@@ -226,3 +226,32 @@ and ordered `stable` → `beta` → `alpha` → `deprecated`, so a reader can te
 is current, which is not final, and which is on the way out. This works for object, type, and enum
 dispatchers alike — each version section renders the body appropriate to its kind (an object/type
 property table, or an enum's value list).
+
+## Choosing Which Versions Ship: the `--experimental` Flag
+
+The dispatcher carries every active versioned shape, but most consumers only want **one**. The
+`--experimental` flag tells the toolchain — the schema composer (`schema:compose`), the TypeScript
+codegen (`schema:gen-types`), and the documentation generator (`docs:generate`) — how to resolve a
+dispatcher. All three accept the same flag and resolve dispatchers identically, so the composed
+schemas, the generated types, and the docs always agree.
+
+| `--experimental` | What it emits for a dispatcher                                                                                                                                                                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compatibility`  | **The default.** The dispatcher is kept intact: the public `$id` accepts the **union** of every listed shape (codegen emits `V1 \| V2 \| …`; the docs fold all versions into one page). Output is unchanged from before the flag existed.                            |
+| `none`           | The dispatcher is **dropped**; the public `$id` exposes only the **latest `stable`** versioned shape. Pre-release / older shapes never reach the public surface. (If a dispatcher has no `stable` shape, the latest shape overall is used and a warning is emitted.) |
+| `unstable`       | The public `$id` exposes the **latest pre-release** (`alpha` or `beta`) shape, falling back to the latest `stable` shape when none is pre-release. Use it to preview the shape OCF is moving toward.                                                                 |
+
+"Latest" is the highest `.v#` number among the candidate shapes. Under `none` / `unstable` the
+dispatcher collapses to the single selected shape — re-homed onto the dispatcher's stable public
+`$id`, with every other versioned shape removed from the output entirely (no standalone type, doc
+page, or composed file). A property that references the dispatcher's public `$id` keeps working:
+that `$id` now resolves to the collapsed shape.
+
+```bash
+# Default: dispatchers stay unions / folded pages.
+npm run schema:gen-types -- --out types.d.ts
+# Pin the public surface to the latest stable shape only.
+npm run schema:gen-types -- --out types.d.ts --experimental none
+# Preview the upcoming (alpha/beta) shape.
+npm run docs:generate -- --experimental unstable
+```

--- a/utils/generate-docs/Schema/Schema.ts
+++ b/utils/generate-docs/Schema/Schema.ts
@@ -12,9 +12,12 @@ import SchemaNodeFactory, {
   SchemaNodeJson,
 } from "./SchemaNode/Factory.js";
 import {
+  applyExperimentalMode,
   composeAll,
+  ExperimentalMode,
   hasVersionSuffix,
   isVersionWrapper,
+  RawSchemaJson,
   versionShapeOwnerMap,
 } from "../../schema-utils/SchemaComposer.js";
 
@@ -30,10 +33,20 @@ export const REPO_ROOT = path.resolve(
  *  Schema represents the OCF schema format.
  */
 export default class Schema {
-  static generateDocs = async () => {
+  static generateDocs = async (
+    experimental: ExperimentalMode = "compatibility"
+  ) => {
     const schemaNodeJsons = await SchemaReader.read(
       path.join(REPO_ROOT, "schema")
     );
+    // Resolve version dispatchers per the experimental policy before rendering.
+    // Under `none` / `unstable` each dispatcher collapses to a single selected
+    // versioned shape (others removed), so its page documents just that shape;
+    // `compatibility` keeps the dispatcher so its versions fold into one page.
+    const resolvedJsons = applyExperimentalMode(
+      schemaNodeJsons as unknown as RawSchemaJson[],
+      experimental
+    ) as unknown as SchemaNodeJson[];
     const exampleJsons = await ExamplesReader.read(
       path.join(REPO_ROOT, "samples")
     );
@@ -41,7 +54,7 @@ export default class Schema {
       path.join(REPO_ROOT, "docs", "supplemental")
     );
     const schema = new Schema(
-      schemaNodeJsons,
+      resolvedJsons,
       exampleJsons,
       supplementalMarkdowns
     );

--- a/utils/generate-docs/Schema/SchemaNode/VersionDispatcherSchemaNode.test.ts
+++ b/utils/generate-docs/Schema/SchemaNode/VersionDispatcherSchemaNode.test.ts
@@ -7,6 +7,10 @@ import VersionedSubschemaNode, {
 } from "./VersionedSubschemaNode.js";
 import { EnumSchemaNodeJson } from "./Enum.js";
 import { PrimitiveSchemaNodeJson } from "./Primitive.js";
+import {
+  applyExperimentalMode,
+  RawSchemaJson,
+} from "../../../schema-utils/SchemaComposer.js";
 
 const BASE =
   "https://raw.githubusercontent.com/Open-Cap-Table-Coalition/Open-Cap-Format-OCF/main/schema";
@@ -198,6 +202,47 @@ describe("VersionDispatcherSchemaNode (version dispatcher)", () => {
       expect(schema.findSchemaNodeById(V2_FIXTURE.$id).writesOwnDoc()).toBe(
         false
       );
+    });
+  });
+
+  // The doc-gen entrypoint applies `applyExperimentalMode` before constructing
+  // the Schema, so `none` / `unstable` collapse the dispatcher to a single shape
+  // BEFORE node building. After that pass the dispatcher is gone and its public
+  // $id is an ordinary page.
+  describe("under --experimental=none (dispatcher collapsed before rendering)", () => {
+    const collapsedSchema = () =>
+      new Schema(
+        applyExperimentalMode(
+          [
+            OBJECT_TYPE_ENUM_FIXTURE,
+            COMPENSATION_TYPE_ENUM_FIXTURE,
+            BASE_OBJECT_FIXTURE,
+            DISPATCHER_FIXTURE,
+            V1_FIXTURE,
+            V2_FIXTURE,
+          ] as RawSchemaJson[],
+          "none"
+        ) as never[]
+      );
+
+    it("documents the public $id as an ordinary page, not a version dispatcher", () => {
+      const node = collapsedSchema().findSchemaNodeById(DISPATCHER_FIXTURE.$id);
+      expect(node).not.toBeInstanceOf(VersionDispatcherSchemaNode);
+      const md = node.markdownOutput();
+      expect(md).not.toContain("version dispatcher");
+      expect(md).not.toContain("**Data Type:** `Versioned OCF Schema`");
+      // It shows the selected (stable v1) shape's properties directly.
+      expect(md).toContain("| compensation_type ");
+    });
+
+    it("drops the versioned shapes entirely (no standalone pages)", () => {
+      const schema = collapsedSchema();
+      expect(() => schema.findSchemaNodeById(V1_FIXTURE.$id)).toThrow();
+      expect(() => schema.findSchemaNodeById(V2_FIXTURE.$id)).toThrow();
+      // The single surviving page for this object writes its own doc.
+      expect(
+        schema.findSchemaNodeById(DISPATCHER_FIXTURE.$id).writesOwnDoc()
+      ).toBe(true);
     });
   });
 });

--- a/utils/generate-docs/index.ts
+++ b/utils/generate-docs/index.ts
@@ -1,38 +1,5 @@
-import {
-  DEFAULT_EXPERIMENTAL_MODE,
-  EXPERIMENTAL_MODES,
-  isExperimentalMode,
-} from "../schema-utils/SchemaComposer.js";
+import { experimentalFromArgv } from "../schema-utils/SchemaComposer.js";
 
 import Schema from "./Schema/Schema.js";
-
-/** Read `--experimental <mode>` (or `--experimental=<mode>`) from argv, falling
- *  back to the default. Kept as a tiny hand-parser so the doc-gen entrypoint
- *  stays dependency-light; the value is validated against the known modes. */
-function experimentalFromArgv(argv: string[]) {
-  const flag = "--experimental";
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === flag) {
-      const value = argv[i + 1];
-      if (!isExperimentalMode(value)) {
-        throw new Error(
-          `--experimental must be one of: ${EXPERIMENTAL_MODES.join(", ")}`
-        );
-      }
-      return value;
-    }
-    if (arg.startsWith(`${flag}=`)) {
-      const value = arg.slice(flag.length + 1);
-      if (!isExperimentalMode(value)) {
-        throw new Error(
-          `--experimental must be one of: ${EXPERIMENTAL_MODES.join(", ")}`
-        );
-      }
-      return value;
-    }
-  }
-  return DEFAULT_EXPERIMENTAL_MODE;
-}
 
 await Schema.generateDocs(experimentalFromArgv(process.argv.slice(2)));

--- a/utils/generate-docs/index.ts
+++ b/utils/generate-docs/index.ts
@@ -1,3 +1,38 @@
+import {
+  DEFAULT_EXPERIMENTAL_MODE,
+  EXPERIMENTAL_MODES,
+  isExperimentalMode,
+} from "../schema-utils/SchemaComposer.js";
+
 import Schema from "./Schema/Schema.js";
 
-await Schema.generateDocs();
+/** Read `--experimental <mode>` (or `--experimental=<mode>`) from argv, falling
+ *  back to the default. Kept as a tiny hand-parser so the doc-gen entrypoint
+ *  stays dependency-light; the value is validated against the known modes. */
+function experimentalFromArgv(argv: string[]) {
+  const flag = "--experimental";
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === flag) {
+      const value = argv[i + 1];
+      if (!isExperimentalMode(value)) {
+        throw new Error(
+          `--experimental must be one of: ${EXPERIMENTAL_MODES.join(", ")}`
+        );
+      }
+      return value;
+    }
+    if (arg.startsWith(`${flag}=`)) {
+      const value = arg.slice(flag.length + 1);
+      if (!isExperimentalMode(value)) {
+        throw new Error(
+          `--experimental must be one of: ${EXPERIMENTAL_MODES.join(", ")}`
+        );
+      }
+      return value;
+    }
+  }
+  return DEFAULT_EXPERIMENTAL_MODE;
+}
+
+await Schema.generateDocs(experimentalFromArgv(process.argv.slice(2)));

--- a/utils/schema-utils/ComposeSchemas.ts
+++ b/utils/schema-utils/ComposeSchemas.ts
@@ -24,8 +24,14 @@ import { hideBin } from "yargs/helpers";
 
 import { getSchemaFilepaths } from "./Loaders.js";
 import {
+  applyExperimentalMode,
   composeAll,
   ComposedSchemaJson,
+  DEFAULT_EXPERIMENTAL_MODE,
+  EXPERIMENTAL_MODES,
+  ExperimentalMode,
+  isExperimentalMode,
+  omitEmptyComposedContainers,
   RawSchemaJson,
 } from "./SchemaComposer.js";
 import { dereferenceAll } from "./SchemaDereferencer.js";
@@ -61,14 +67,16 @@ async function writeComposedSchema(
 ): Promise<void> {
   const targetPath = path.join(outDir, relPath);
   await mkdir(path.dirname(targetPath), { recursive: true });
-  await writeFile(targetPath, JSON.stringify(composed, null, 2) + "\n");
+  const output = omitEmptyComposedContainers(composed);
+  await writeFile(targetPath, JSON.stringify(output, null, 2) + "\n");
   if (verbose) console.log(`\t• wrote ${targetPath}`);
 }
 
 export async function composeSchemasToDir(
   outDir: string,
   verbose: boolean = false,
-  dereference: boolean = false
+  dereference: boolean = false,
+  experimental: ExperimentalMode = "compatibility"
 ): Promise<{ written: number }> {
   await mkdir(outDir, { recursive: true });
 
@@ -76,16 +84,35 @@ export async function composeSchemasToDir(
   const rawEntries = await readRawSchemas(verbose);
   const rawJsons = rawEntries.map((e) => e.json);
 
+  // Resolve version dispatchers per the experimental policy. Under `none` /
+  // `unstable` each dispatcher collapses to its selected versioned shape (kept
+  // at the dispatcher's public `$id`) and the other version shapes drop out of
+  // the set — so those source files are skipped on write below.
+  const processed = applyExperimentalMode(rawJsons, experimental);
+  const survivingIds = new Set(processed.map((s) => s.$id));
+
   const verb = dereference ? "Dereferencing" : "Composing";
-  if (verbose) console.log(`\n${verb} ${rawEntries.length} schemas ...`);
+  if (verbose)
+    console.log(
+      `\n${verb} ${processed.length} schemas (--experimental=${experimental}) ...`
+    );
   const resultById = dereference
-    ? dereferenceAll(rawJsons).dereferencedById
-    : composeAll(rawJsons).composedById;
+    ? dereferenceAll(processed).dereferencedById
+    : composeAll(processed).composedById;
 
   if (verbose)
     console.log(`\nWriting ${verb.toLowerCase()} schemas to ${outDir} ...`);
   let written = 0;
   for (const { relPath, json } of rawEntries) {
+    // A versioned shape that the experimental policy folded into its
+    // dispatcher's public `$id`: its source file has no standalone output.
+    if (!survivingIds.has(json.$id)) {
+      if (verbose)
+        console.log(
+          `\t• skipped ${relPath} (folded by --experimental=${experimental})`
+        );
+      continue;
+    }
     const result = resultById[json.$id];
     if (!result) {
       throw new Error(`Missing composed output for ${json.$id}`);
@@ -106,6 +133,7 @@ interface ComposeSchemasArgs extends Arguments {
   v?: boolean;
   dereference?: boolean;
   d?: boolean;
+  experimental?: string;
 }
 
 // Only wire up the CLI when this module is the entrypoint (not when
@@ -137,6 +165,12 @@ if (invokedAsScript) {
           type: "boolean",
           default: false,
         },
+        experimental: {
+          describe:
+            "How to resolve version dispatchers. 'compatibility' (default): write the dispatcher and every version file as-is. 'none': write only the latest stable versioned shape at the public $id and skip the other version files. 'unstable': write the latest alpha/beta shape (else latest stable).",
+          choices: EXPERIMENTAL_MODES as unknown as string[],
+          default: DEFAULT_EXPERIMENTAL_MODE,
+        },
         verbose: {
           describe: "Print per-file progress.",
           alias: "v",
@@ -152,7 +186,10 @@ if (invokedAsScript) {
         );
         const verbose = Boolean(argv.verbose ?? argv.v);
         const dereference = Boolean(argv.dereference ?? argv.d);
-        await composeSchemasToDir(outDir, verbose, dereference);
+        const experimental = isExperimentalMode(argv.experimental)
+          ? argv.experimental
+          : DEFAULT_EXPERIMENTAL_MODE;
+        await composeSchemasToDir(outDir, verbose, dereference, experimental);
       },
     })
     .help()

--- a/utils/schema-utils/ComposeSchemas.ts
+++ b/utils/schema-utils/ComposeSchemas.ts
@@ -25,12 +25,12 @@ import { hideBin } from "yargs/helpers";
 import { getSchemaFilepaths } from "./Loaders.js";
 import {
   applyExperimentalMode,
+  coerceExperimentalMode,
   composeAll,
   ComposedSchemaJson,
   DEFAULT_EXPERIMENTAL_MODE,
   EXPERIMENTAL_MODES,
   ExperimentalMode,
-  isExperimentalMode,
   omitEmptyComposedContainers,
   RawSchemaJson,
 } from "./SchemaComposer.js";
@@ -186,9 +186,7 @@ if (invokedAsScript) {
         );
         const verbose = Boolean(argv.verbose ?? argv.v);
         const dereference = Boolean(argv.dereference ?? argv.d);
-        const experimental = isExperimentalMode(argv.experimental)
-          ? argv.experimental
-          : DEFAULT_EXPERIMENTAL_MODE;
+        const experimental = coerceExperimentalMode(argv.experimental);
         await composeSchemasToDir(outDir, verbose, dereference, experimental);
       },
     })

--- a/utils/schema-utils/GenerateTypes.ts
+++ b/utils/schema-utils/GenerateTypes.ts
@@ -18,10 +18,10 @@ import { hideBin } from "yargs/helpers";
 
 import { getSchemaFilepaths } from "./Loaders.js";
 import {
+  coerceExperimentalMode,
   DEFAULT_EXPERIMENTAL_MODE,
   EXPERIMENTAL_MODES,
   ExperimentalMode,
-  isExperimentalMode,
   RawSchemaJson,
 } from "./SchemaComposer.js";
 import { generateTypeScript } from "./TypeScriptGenerator.js";
@@ -158,9 +158,7 @@ if (invokedAsScript) {
           process.cwd(),
           (argv.out ?? argv.o) as string
         );
-        const experimental = isExperimentalMode(argv.experimental)
-          ? argv.experimental
-          : DEFAULT_EXPERIMENTAL_MODE;
+        const experimental = coerceExperimentalMode(argv.experimental);
         const { warnings } = await generateTypesToFile(outFile, {
           verbose: Boolean(argv.verbose ?? argv.v),
           typePrefix: argv.prefix as string | undefined,

--- a/utils/schema-utils/GenerateTypes.ts
+++ b/utils/schema-utils/GenerateTypes.ts
@@ -17,7 +17,13 @@ import yargs, { Arguments } from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { getSchemaFilepaths } from "./Loaders.js";
-import { RawSchemaJson } from "./SchemaComposer.js";
+import {
+  DEFAULT_EXPERIMENTAL_MODE,
+  EXPERIMENTAL_MODES,
+  ExperimentalMode,
+  isExperimentalMode,
+  RawSchemaJson,
+} from "./SchemaComposer.js";
 import { generateTypeScript } from "./TypeScriptGenerator.js";
 
 const SCHEMA_DIR = "schema";
@@ -39,6 +45,7 @@ export async function generateTypesToFile(
     typePrefix?: string;
     includeDescriptions?: boolean;
     includePrimitives?: boolean;
+    experimental?: ExperimentalMode;
   } = {}
 ): Promise<{ outFile: string; typeCount: number; warnings: string[] }> {
   const {
@@ -46,17 +53,21 @@ export async function generateTypesToFile(
     typePrefix,
     includeDescriptions,
     includePrimitives,
+    experimental = DEFAULT_EXPERIMENTAL_MODE,
   } = options;
 
   if (verbose) console.log(`\nReading raw schemas from ./${SCHEMA_DIR} ...`);
   const rawSchemas = await readRawSchemas(verbose);
 
   if (verbose)
-    console.log(`\nGenerating types for ${rawSchemas.length} schemas ...`);
+    console.log(
+      `\nGenerating types for ${rawSchemas.length} schemas (--experimental=${experimental}) ...`
+    );
   const { source, typeNames, warnings } = generateTypeScript(rawSchemas, {
     typePrefix,
     includeDescriptions,
     includePrimitives,
+    experimental,
   });
 
   await mkdir(path.dirname(outFile), { recursive: true });
@@ -77,6 +88,7 @@ interface GenerateTypesArgs extends Arguments {
   prefix?: string;
   descriptions?: boolean;
   includePrimitives?: boolean;
+  experimental?: string;
   failOnWarnings?: boolean;
   verbose?: boolean;
   v?: boolean;
@@ -121,6 +133,12 @@ if (invokedAsScript) {
           type: "boolean",
           default: false,
         },
+        experimental: {
+          describe:
+            "How to resolve version dispatchers. 'compatibility' (default): emit a V1 | V2 | … union of every version. 'none': emit only the latest stable versioned shape. 'unstable': emit the latest alpha/beta shape (else latest stable).",
+          choices: EXPERIMENTAL_MODES as unknown as string[],
+          default: DEFAULT_EXPERIMENTAL_MODE,
+        },
         "fail-on-warnings": {
           describe:
             "Exit non-zero if generation produces any warnings (e.g. unresolved $refs). Use as a CI guard, since the output is not committed.",
@@ -140,11 +158,15 @@ if (invokedAsScript) {
           process.cwd(),
           (argv.out ?? argv.o) as string
         );
+        const experimental = isExperimentalMode(argv.experimental)
+          ? argv.experimental
+          : DEFAULT_EXPERIMENTAL_MODE;
         const { warnings } = await generateTypesToFile(outFile, {
           verbose: Boolean(argv.verbose ?? argv.v),
           typePrefix: argv.prefix as string | undefined,
           includeDescriptions: argv.descriptions as boolean | undefined,
           includePrimitives: argv.includePrimitives as boolean | undefined,
+          experimental,
         });
         if (argv.failOnWarnings && warnings.length > 0) {
           console.error(

--- a/utils/schema-utils/SchemaComposer.test.ts
+++ b/utils/schema-utils/SchemaComposer.test.ts
@@ -1,10 +1,12 @@
 import {
   applyExperimentalMode,
   buildSchemaRegistry,
+  coerceExperimentalMode,
   composeAll,
   composeSchema,
   DEFAULT_EXPERIMENTAL_MODE,
   DEFAULT_STABILITY,
+  experimentalFromArgv,
   EXPERIMENTAL_MODES,
   hasVersionSuffix,
   isBackwardsCompatibleWrapper,
@@ -562,6 +564,46 @@ describe("SchemaComposer", () => {
     });
   });
 
+  describe("coerceExperimentalMode", () => {
+    it("passes a known mode through unchanged", () => {
+      expect(coerceExperimentalMode("none")).toBe("none");
+      expect(coerceExperimentalMode("unstable")).toBe("unstable");
+    });
+    it("falls back to the default for an absent or unknown value", () => {
+      expect(coerceExperimentalMode(undefined)).toBe(DEFAULT_EXPERIMENTAL_MODE);
+      expect(coerceExperimentalMode("nope")).toBe(DEFAULT_EXPERIMENTAL_MODE);
+    });
+  });
+
+  describe("experimentalFromArgv", () => {
+    it("reads the space-separated form (--experimental none)", () => {
+      expect(experimentalFromArgv(["--experimental", "none"])).toBe("none");
+    });
+    it("reads the = form (--experimental=unstable)", () => {
+      expect(experimentalFromArgv(["--experimental=unstable"])).toBe(
+        "unstable"
+      );
+    });
+    it("returns the default when the flag is absent", () => {
+      expect(experimentalFromArgv(["--out", "types.d.ts"])).toBe(
+        DEFAULT_EXPERIMENTAL_MODE
+      );
+    });
+    it("throws on an unrecognized value (either form)", () => {
+      expect(() => experimentalFromArgv(["--experimental", "nope"])).toThrow(
+        /--experimental must be one of/
+      );
+      expect(() => experimentalFromArgv(["--experimental=nope"])).toThrow(
+        /--experimental must be one of/
+      );
+    });
+    it("throws when the flag is given with no value (end of argv)", () => {
+      expect(() => experimentalFromArgv(["--experimental"])).toThrow(
+        /--experimental must be one of/
+      );
+    });
+  });
+
   describe("selectVersionForMode", () => {
     it("none: picks the latest strictly-stable shape", () => {
       const versions = [
@@ -685,6 +727,19 @@ describe("SchemaComposer", () => {
       )!;
       expect(collapsed.properties?.field_v2).toEqual({ type: "string" });
       expect((collapsed as any)["x-ocf-stability"]).toBe("alpha");
+    });
+
+    it("keeps the selected shape's title/description when the dispatcher's are empty", () => {
+      const input = [
+        { ...demoDispatcher([1]), title: "", description: "" },
+        vShape(1, "stable"),
+      ];
+      const collapsed = applyExperimentalMode(input, "none").find(
+        (s) => s.$id === "test://demo/Demo.schema.json"
+      )!;
+      // An empty dispatcher title/description must not clobber the shape's own.
+      expect(collapsed.title).toBe("Demo v1");
+      expect(collapsed.description).toBe("Demo shape v1");
     });
 
     it("none: warns and uses the latest shape overall when no stable shape exists", () => {

--- a/utils/schema-utils/SchemaComposer.test.ts
+++ b/utils/schema-utils/SchemaComposer.test.ts
@@ -1,17 +1,24 @@
 import {
+  applyExperimentalMode,
   buildSchemaRegistry,
   composeAll,
   composeSchema,
+  DEFAULT_EXPERIMENTAL_MODE,
   DEFAULT_STABILITY,
+  EXPERIMENTAL_MODES,
   hasVersionSuffix,
   isBackwardsCompatibleWrapper,
+  isExperimentalMode,
   isVersionWrapper,
   MissingRefError,
   objectTypeValues,
+  omitEmptyComposedContainers,
   RawSchemaJson,
+  selectVersionForMode,
   STABILITY_RANK,
   stabilityOf,
   versionLabelOf,
+  versionNumberOf,
   versionRefsOf,
   versionShapeOwnerMap,
 } from "./SchemaComposer.js";
@@ -499,6 +506,256 @@ describe("SchemaComposer", () => {
       ]);
       // The stability flag is carried through untouched.
       expect((composed as any)["x-ocf-stability"]).toBe("alpha");
+    });
+  });
+
+  // ---- Experimental mode (version-dispatcher resolution policy) ----------
+
+  // A self-contained dispatcher + versioned-shape fixture set, with explicit
+  // `.v#` ids and stabilities, used by the selection / collapse tests below.
+  const vShape = (
+    n: number,
+    stability: string,
+    extra: Record<string, unknown> = {}
+  ): RawSchemaJson => ({
+    $id: `test://demo/versions/Demo.v${n}.schema.json`,
+    title: `Demo v${n}`,
+    description: `Demo shape v${n}`,
+    type: "object",
+    ["x-ocf-stability"]: stability,
+    properties: {
+      object_type: { const: "TX_DEMO" },
+      [`field_v${n}`]: { type: "string" },
+    },
+    required: [`field_v${n}`],
+    additionalProperties: false,
+    ...extra,
+  });
+  const demoDispatcher = (refs: number[]): RawSchemaJson => ({
+    $id: "test://demo/Demo.schema.json",
+    title: "Demo",
+    description: "Public Demo dispatcher",
+    ["x-ocf-version-dispatcher"]: true,
+    anyOf: refs.map((n) => ({
+      $ref: `test://demo/versions/Demo.v${n}.schema.json`,
+    })),
+  });
+  const idsOf = (schemas: RawSchemaJson[]) => schemas.map((s) => s.$id);
+
+  describe("versionNumberOf", () => {
+    it("extracts the numeric version from a .v# id/ref/basename", () => {
+      expect(versionNumberOf("test://Foo.v3.schema.json")).toBe(3);
+      expect(versionNumberOf("Foo.v12")).toBe(12);
+    });
+    it("returns null when there is no .v# suffix", () => {
+      expect(versionNumberOf("test://Foo.schema.json")).toBeNull();
+    });
+  });
+
+  describe("isExperimentalMode", () => {
+    it("accepts the known modes and rejects others", () => {
+      for (const mode of EXPERIMENTAL_MODES)
+        expect(isExperimentalMode(mode)).toBe(true);
+      expect(isExperimentalMode("nope")).toBe(false);
+      expect(isExperimentalMode(undefined)).toBe(false);
+      expect(DEFAULT_EXPERIMENTAL_MODE).toBe("compatibility");
+    });
+  });
+
+  describe("selectVersionForMode", () => {
+    it("none: picks the latest strictly-stable shape", () => {
+      const versions = [
+        vShape(1, "stable"),
+        vShape(2, "stable"),
+        vShape(3, "alpha"),
+      ];
+      const result = selectVersionForMode(versions, "none");
+      expect(result?.selected.$id).toBe(
+        "test://demo/versions/Demo.v2.schema.json"
+      );
+      expect(result?.fallback).toBe(false);
+    });
+
+    it("none: ignores a higher-numbered non-stable shape", () => {
+      const versions = [
+        vShape(1, "stable"),
+        vShape(2, "beta"),
+        vShape(3, "alpha"),
+      ];
+      expect(selectVersionForMode(versions, "none")?.selected.$id).toBe(
+        "test://demo/versions/Demo.v1.schema.json"
+      );
+    });
+
+    it("none: falls back to the latest shape overall when nothing is stable", () => {
+      const versions = [vShape(1, "deprecated"), vShape(2, "alpha")];
+      const result = selectVersionForMode(versions, "none");
+      expect(result?.selected.$id).toBe(
+        "test://demo/versions/Demo.v2.schema.json"
+      );
+      expect(result?.fallback).toBe(true);
+    });
+
+    it("unstable: picks the latest alpha/beta shape", () => {
+      const versions = [
+        vShape(1, "stable"),
+        vShape(2, "beta"),
+        vShape(3, "alpha"),
+      ];
+      expect(selectVersionForMode(versions, "unstable")?.selected.$id).toBe(
+        "test://demo/versions/Demo.v3.schema.json"
+      );
+    });
+
+    it("unstable: prefers a beta over an older alpha (latest pre-release wins)", () => {
+      const versions = [vShape(1, "alpha"), vShape(2, "beta")];
+      expect(selectVersionForMode(versions, "unstable")?.selected.$id).toBe(
+        "test://demo/versions/Demo.v2.schema.json"
+      );
+    });
+
+    it("unstable: falls back to the latest stable when no pre-release exists", () => {
+      const versions = [vShape(1, "stable"), vShape(2, "stable")];
+      const result = selectVersionForMode(versions, "unstable");
+      expect(result?.selected.$id).toBe(
+        "test://demo/versions/Demo.v2.schema.json"
+      );
+      expect(result?.fallback).toBe(false);
+    });
+
+    it("returns null for an empty version list", () => {
+      expect(selectVersionForMode([], "none")).toBeNull();
+    });
+  });
+
+  describe("applyExperimentalMode", () => {
+    const OTHER: RawSchemaJson = {
+      $id: "test://other",
+      type: "object",
+      properties: { x: { type: "string" } },
+    };
+
+    it("compatibility: returns the input unchanged (dispatcher + all versions kept)", () => {
+      const input = [
+        OTHER,
+        demoDispatcher([1, 2]),
+        vShape(1, "stable"),
+        vShape(2, "alpha"),
+      ];
+      const result = applyExperimentalMode(input, "compatibility");
+      expect(result).toBe(input);
+    });
+
+    it("none: collapses the dispatcher to the latest stable shape and drops the version files", () => {
+      const input = [
+        OTHER,
+        demoDispatcher([1, 2]),
+        vShape(1, "stable"),
+        vShape(2, "alpha"),
+      ];
+      const result = applyExperimentalMode(input, "none");
+
+      // Only OTHER and the (collapsed) public dispatcher id survive.
+      expect(idsOf(result).sort()).toEqual(
+        ["test://demo/Demo.schema.json", "test://other"].sort()
+      );
+
+      const collapsed = result.find(
+        (s) => s.$id === "test://demo/Demo.schema.json"
+      )!;
+      // It IS the selected (v1/stable) shape, re-homed onto the public id...
+      expect(collapsed.properties?.field_v1).toEqual({ type: "string" });
+      expect(collapsed.type).toBe("object");
+      // ...with the dispatcher's public identity and no union/marker leftovers.
+      expect(collapsed.title).toBe("Demo");
+      expect(collapsed.description).toBe("Public Demo dispatcher");
+      expect(collapsed.anyOf).toBeUndefined();
+      expect((collapsed as any)["x-ocf-version-dispatcher"]).toBeUndefined();
+    });
+
+    it("unstable: collapses to the latest alpha/beta shape", () => {
+      const input = [
+        demoDispatcher([1, 2]),
+        vShape(1, "stable"),
+        vShape(2, "alpha"),
+      ];
+      const result = applyExperimentalMode(input, "unstable");
+      const collapsed = result.find(
+        (s) => s.$id === "test://demo/Demo.schema.json"
+      )!;
+      expect(collapsed.properties?.field_v2).toEqual({ type: "string" });
+      expect((collapsed as any)["x-ocf-stability"]).toBe("alpha");
+    });
+
+    it("none: warns and uses the latest shape overall when no stable shape exists", () => {
+      const original = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map(String).join(" "));
+      };
+      try {
+        const input = [
+          demoDispatcher([1, 2]),
+          vShape(1, "deprecated"),
+          vShape(2, "alpha"),
+        ];
+        const result = applyExperimentalMode(input, "none");
+        const collapsed = result.find(
+          (s) => s.$id === "test://demo/Demo.schema.json"
+        )!;
+        expect(collapsed.properties?.field_v2).toEqual({ type: "string" });
+        expect(
+          warnings.some((m) => m.includes("no stable versioned shape"))
+        ).toBe(true);
+      } finally {
+        console.warn = original;
+      }
+    });
+
+    it("leaves a non-dispatcher schema set untouched", () => {
+      const input = [OTHER, STOCK_ISSUANCE, BASE_OBJECT];
+      expect(applyExperimentalMode(input, "none")).toBe(input);
+    });
+  });
+
+  describe("omitEmptyComposedContainers", () => {
+    it("drops a vacuous properties:{} and required:[] (e.g. a composed enum)", () => {
+      const enumComposed = {
+        $id: "test://enum",
+        type: "string",
+        enum: ["A", "B"],
+        properties: {},
+        required: [],
+      };
+      const cleaned = omitEmptyComposedContainers(enumComposed);
+      expect("properties" in cleaned).toBe(false);
+      expect("required" in cleaned).toBe(false);
+      // Other fields are preserved and the input is not mutated.
+      expect(cleaned.enum).toEqual(["A", "B"]);
+      expect("properties" in enumComposed).toBe(true);
+    });
+
+    it("keeps non-empty properties and required", () => {
+      const objectComposed = {
+        $id: "test://obj",
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const cleaned = omitEmptyComposedContainers(objectComposed);
+      expect(cleaned.properties).toEqual({ id: { type: "string" } });
+      expect(cleaned.required).toEqual(["id"]);
+    });
+
+    it("drops only the empty side when one is empty", () => {
+      const cleaned = omitEmptyComposedContainers({
+        $id: "test://x",
+        type: "object",
+        properties: { a: {} },
+        required: [],
+      });
+      expect(cleaned.properties).toEqual({ a: {} });
+      expect("required" in cleaned).toBe(false);
     });
   });
 });

--- a/utils/schema-utils/SchemaComposer.ts
+++ b/utils/schema-utils/SchemaComposer.ts
@@ -160,6 +160,17 @@ export function versionLabelOf(idOrRef: string): string | null {
   return match ? match[1] : null;
 }
 
+/** The numeric version pulled from a versioned-shape `$id`/`$ref`/basename
+ *  (e.g. `2` for `…EquityCompensationIssuance.v2.schema.json`), or `null` when
+ *  there is no `.v#` suffix. This is the ordering key for "which version is the
+ *  latest" when `--experimental` collapses a dispatcher to a single shape. */
+export function versionNumberOf(idOrRef: string): number | null {
+  const label = versionLabelOf(idOrRef);
+  if (!label) return null;
+  const n = Number.parseInt(label.slice(1), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
 /**
  * A "version dispatcher" (VersionWrapper) is the versioned analogue of the
  * backwards-compatibility wrapper. The stable, public `$id` lives on a thin
@@ -266,6 +277,202 @@ export function objectTypeValues(objectType: unknown): string[] {
     return ot.enum.filter((v): v is string => typeof v === "string");
   }
   return [];
+}
+
+// ---------------------------------------------------------------------------
+// Experimental mode (version-dispatcher resolution policy)
+// ---------------------------------------------------------------------------
+
+/**
+ * How the toolchain (composer, TypeScript codegen, doc generator) treats a
+ * version dispatcher. Selected by the `--experimental` CLI flag.
+ *
+ *   - `compatibility` (the default): keep the dispatcher as-is — the public
+ *     `$id` accepts the union of every listed shape (codegen emits
+ *     `V1 | V2 | …`; the docs fold all versions into one page). This is the
+ *     historical behavior, so the default output is unchanged.
+ *   - `none`: drop the dispatcher entirely and expose only the latest **stable**
+ *     versioned shape under the dispatcher's public `$id`. The pre-release /
+ *     older shapes never reach the public surface.
+ *   - `unstable`: expose the latest **pre-release** (alpha or beta) versioned
+ *     shape, falling back to the latest stable shape when none is pre-release.
+ *     Use this to preview the shape OCF is moving toward.
+ *
+ * `none` and `unstable` both *collapse* a dispatcher to a single chosen shape
+ * (re-homed onto the public `$id`, with every other version shape removed from
+ * the output). They differ only in which shape they pick.
+ */
+export const EXPERIMENTAL_MODES = [
+  "none",
+  "compatibility",
+  "unstable",
+] as const;
+
+export type ExperimentalMode = typeof EXPERIMENTAL_MODES[number];
+
+/** The default the `--experimental` flag carries when omitted: `compatibility`,
+ *  so the toolchain's default output is unchanged from before the flag existed
+ *  (dispatchers stay unions / folded pages). Opt into `none` / `unstable`
+ *  explicitly to collapse dispatchers to a single shape. */
+export const DEFAULT_EXPERIMENTAL_MODE: ExperimentalMode = "compatibility";
+
+/** Narrow an arbitrary string to an `ExperimentalMode` (for CLI arg parsing). */
+export function isExperimentalMode(value: unknown): value is ExperimentalMode {
+  return (EXPERIMENTAL_MODES as readonly string[]).includes(value as string);
+}
+
+/**
+ * Pick the single versioned shape a collapsing mode (`none` / `unstable`)
+ * exposes, from a dispatcher's resolved version shapes (in `anyOf` declaration
+ * order). "Latest" is the highest `.v#` number, falling back to declaration
+ * order for any shape without a numeric suffix.
+ *
+ *   - `none`: the latest shape whose stability is exactly `stable`.
+ *   - `unstable`: the latest `alpha`/`beta` shape; failing that, the latest
+ *     `stable` shape.
+ *
+ * When neither pool yields a shape (e.g. a dispatcher of only `deprecated`
+ * shapes), it falls back to the latest shape overall and flags `fallback: true`
+ * so the caller can warn. Returns `null` only for an empty input.
+ */
+export function selectVersionForMode(
+  versions: RawSchemaJson[],
+  mode: "none" | "unstable"
+): { selected: RawSchemaJson; fallback: boolean } | null {
+  if (versions.length === 0) return null;
+
+  const ranked = versions.map((json, index) => ({
+    json,
+    stability: stabilityOf(json),
+    rank: versionNumberOf(json.$id) ?? index,
+  }));
+  const latest = (pool: typeof ranked) =>
+    pool.length
+      ? pool.reduce((best, c) => (c.rank > best.rank ? c : best))
+      : null;
+
+  if (mode === "none") {
+    const stable = latest(ranked.filter((c) => c.stability === "stable"));
+    if (stable) return { selected: stable.json, fallback: false };
+  } else {
+    const preRelease = latest(
+      ranked.filter((c) => c.stability === "alpha" || c.stability === "beta")
+    );
+    if (preRelease) return { selected: preRelease.json, fallback: false };
+    const stable = latest(ranked.filter((c) => c.stability === "stable"));
+    if (stable) return { selected: stable.json, fallback: false };
+  }
+
+  // Nothing in the preferred pool(s): expose the latest shape regardless of
+  // stability rather than emit an empty dispatcher, and let the caller warn.
+  return { selected: latest(ranked)!.json, fallback: true };
+}
+
+/**
+ * Re-home a selected versioned shape onto its dispatcher's stable public `$id`,
+ * producing a normal standalone schema. The dispatcher's public identity
+ * (`title` / `description`) wins when present; the union body and the
+ * `x-ocf-version-dispatcher` marker are dropped (they belong to the dispatcher,
+ * not the shape). The selected shape's own `allOf`, `properties`, `required`,
+ * `additionalProperties`, and `x-ocf-stability` carry through untouched so
+ * downstream composition/codegen/docs treat it like any other schema.
+ */
+function collapseDispatcherToVersion(
+  dispatcher: RawSchemaJson,
+  version: RawSchemaJson
+): RawSchemaJson {
+  const collapsed: RawSchemaJson = { ...version, $id: dispatcher.$id };
+  if (typeof dispatcher.title === "string") collapsed.title = dispatcher.title;
+  if (typeof dispatcher.description === "string") {
+    collapsed.description = dispatcher.description;
+  }
+  delete (collapsed as Record<string, unknown>)[VERSION_DISPATCHER_KEYWORD];
+  delete (collapsed as Record<string, unknown>).anyOf;
+  return collapsed;
+}
+
+/**
+ * Apply the `--experimental` policy to a flat list of raw schemas BEFORE any
+ * composition, codegen, or doc rendering. This is the single shared entry point
+ * all three tools call, so they resolve dispatchers identically.
+ *
+ *   - `compatibility`: a no-op — the dispatchers are left intact and the
+ *     existing dispatcher-aware code paths handle the union / folded page.
+ *   - `none` / `unstable`: every version dispatcher is replaced by its selected
+ *     shape (see `selectVersionForMode`) re-homed onto the public `$id`, and
+ *     every versioned shape it owned is removed from the set. After this pass
+ *     there are no dispatchers left, so downstream tooling sees only ordinary
+ *     schemas and needs no per-mode special-casing.
+ *
+ * Schemas that reference a dispatcher's public `$id` keep working: that `$id`
+ * now resolves to the collapsed shape. (Per the VersionWrapper convention,
+ * properties reference the public `$id`, never a `.v#` shape directly, so the
+ * removed version shapes leave no dangling references.)
+ */
+export function applyExperimentalMode(
+  rawSchemas: RawSchemaJson[],
+  mode: ExperimentalMode
+): RawSchemaJson[] {
+  if (mode === "compatibility") return rawSchemas;
+
+  const registry = buildSchemaRegistry(rawSchemas);
+  const droppedVersionIds = new Set<string>();
+  const collapsedByDispatcherId = new Map<string, RawSchemaJson>();
+
+  for (const schema of rawSchemas) {
+    if (!isVersionWrapper(schema)) continue;
+
+    const resolved: RawSchemaJson[] = [];
+    for (const ref of versionRefsOf(schema)) {
+      const target = registry[ref];
+      if (!target) {
+        console.warn(
+          `--experimental=${mode}: version dispatcher ${schema.$id} references ` +
+            `${ref}, which is not in the schema set; ignoring it.`
+        );
+        continue;
+      }
+      resolved.push(target);
+    }
+
+    if (resolved.length === 0) {
+      console.warn(
+        `--experimental=${mode}: version dispatcher ${schema.$id} has no ` +
+          `resolvable versioned shapes; leaving it unchanged.`
+      );
+      continue;
+    }
+
+    const selection = selectVersionForMode(resolved, mode)!;
+    if (selection.fallback) {
+      const wanted = mode === "none" ? "stable" : "alpha/beta or stable";
+      console.warn(
+        `--experimental=${mode}: version dispatcher ${schema.$id} has no ` +
+          `${wanted} versioned shape; falling back to ${selection.selected.$id} ` +
+          `(${stabilityOf(selection.selected)}).`
+      );
+    }
+
+    for (const version of resolved) droppedVersionIds.add(version.$id);
+    collapsedByDispatcherId.set(
+      schema.$id,
+      collapseDispatcherToVersion(schema, selection.selected)
+    );
+  }
+
+  if (collapsedByDispatcherId.size === 0) return rawSchemas;
+
+  const result: RawSchemaJson[] = [];
+  for (const schema of rawSchemas) {
+    const collapsed = collapsedByDispatcherId.get(schema.$id);
+    if (collapsed) {
+      result.push(collapsed);
+      continue;
+    }
+    if (droppedVersionIds.has(schema.$id)) continue;
+    result.push(schema);
+  }
+  return result;
 }
 
 /**
@@ -433,4 +640,32 @@ export function composeAll(
   const composedById: { [id: string]: ComposedSchemaJson } = {};
   for (const c of composed) composedById[c.$id] = c;
   return { registry, composed, composedById };
+}
+
+/**
+ * Drop a vacuous `properties: {}` / `required: []` from a composed (or
+ * dereferenced) schema before it is serialized to a file. The composer defaults
+ * both fields on every schema so the in-memory shape is uniform, but a written
+ * enum or scalar-type schema has no properties and no required list — emitting
+ * the empty containers just adds noise to the output. Non-empty values and
+ * object schemas are left untouched. Returns a shallow clone; the input is not
+ * mutated.
+ */
+export function omitEmptyComposedContainers<T extends Record<string, any>>(
+  schema: T
+): T {
+  const clone: Record<string, any> = { ...schema };
+  const properties = clone.properties;
+  if (
+    properties &&
+    typeof properties === "object" &&
+    !Array.isArray(properties) &&
+    Object.keys(properties).length === 0
+  ) {
+    delete clone.properties;
+  }
+  if (Array.isArray(clone.required) && clone.required.length === 0) {
+    delete clone.required;
+  }
+  return clone as T;
 }

--- a/utils/schema-utils/SchemaComposer.ts
+++ b/utils/schema-utils/SchemaComposer.ts
@@ -321,6 +321,36 @@ export function isExperimentalMode(value: unknown): value is ExperimentalMode {
   return (EXPERIMENTAL_MODES as readonly string[]).includes(value as string);
 }
 
+/** Coerce a parsed CLI value to an `ExperimentalMode`, falling back to the
+ *  default when it is absent or unrecognized. The yargs CLIs validate the flag
+ *  via `choices` first, so this just narrows the parsed string to the union
+ *  type; entrypoints without yargs use `experimentalFromArgv` instead. */
+export function coerceExperimentalMode(value: unknown): ExperimentalMode {
+  return isExperimentalMode(value) ? value : DEFAULT_EXPERIMENTAL_MODE;
+}
+
+/** Parse `--experimental <mode>` / `--experimental=<mode>` from a raw argv
+ *  slice, falling back to the default when the flag is absent and throwing on an
+ *  unrecognized value. A dependency-light parser for entrypoints that don't wire
+ *  up yargs (the doc generator); the yargs CLIs use `coerceExperimentalMode`. */
+export function experimentalFromArgv(argv: string[]): ExperimentalMode {
+  const flag = "--experimental";
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    let value: string | undefined;
+    if (arg === flag) value = argv[i + 1];
+    else if (arg.startsWith(`${flag}=`)) value = arg.slice(flag.length + 1);
+    else continue;
+    if (!isExperimentalMode(value)) {
+      throw new Error(
+        `--experimental must be one of: ${EXPERIMENTAL_MODES.join(", ")}`
+      );
+    }
+    return value;
+  }
+  return DEFAULT_EXPERIMENTAL_MODE;
+}
+
 /**
  * Pick the single versioned shape a collapsing mode (`none` / `unstable`)
  * exposes, from a dispatcher's resolved version shapes (in `anyOf` declaration
@@ -371,7 +401,8 @@ export function selectVersionForMode(
 /**
  * Re-home a selected versioned shape onto its dispatcher's stable public `$id`,
  * producing a normal standalone schema. The dispatcher's public identity
- * (`title` / `description`) wins when present; the union body and the
+ * (`title` / `description`) wins when non-empty, otherwise the selected shape's
+ * own title/description is kept; the union body and the
  * `x-ocf-version-dispatcher` marker are dropped (they belong to the dispatcher,
  * not the shape). The selected shape's own `allOf`, `properties`, `required`,
  * `additionalProperties`, and `x-ocf-stability` carry through untouched so
@@ -382,10 +413,8 @@ function collapseDispatcherToVersion(
   version: RawSchemaJson
 ): RawSchemaJson {
   const collapsed: RawSchemaJson = { ...version, $id: dispatcher.$id };
-  if (typeof dispatcher.title === "string") collapsed.title = dispatcher.title;
-  if (typeof dispatcher.description === "string") {
-    collapsed.description = dispatcher.description;
-  }
+  if (dispatcher.title) collapsed.title = dispatcher.title;
+  if (dispatcher.description) collapsed.description = dispatcher.description;
   delete (collapsed as Record<string, unknown>)[VERSION_DISPATCHER_KEYWORD];
   delete (collapsed as Record<string, unknown>).anyOf;
   return collapsed;

--- a/utils/schema-utils/TypeScriptGenerator.test.ts
+++ b/utils/schema-utils/TypeScriptGenerator.test.ts
@@ -700,5 +700,71 @@ describe("TypeScriptGenerator", () => {
         "TX_EQUITY_COMPENSATION_ISSUANCE: OCFEquityCompensationIssuance;"
       );
     });
+
+    // The default mode is `compatibility` (above). `none` / `unstable` collapse
+    // the dispatcher to a single selected shape under the public $id and drop
+    // the other versioned shapes entirely.
+    it("experimental=none: emits the public $id as the latest stable shape, no .v# types", () => {
+      const { source } = generateTypeScript(inputs, { experimental: "none" });
+      // The public type is now a plain interface for v1 (the only stable shape),
+      // NOT a union and NOT an alias to a versioned type.
+      expect(source).toContain(
+        "export interface OCFEquityCompensationIssuance {"
+      );
+      expect(source).not.toContain(
+        "export type OCFEquityCompensationIssuance ="
+      );
+      // The versioned shapes are gone from the public surface.
+      expect(source).not.toContain("OCFEquityCompensationIssuanceV1");
+      expect(source).not.toContain("OCFEquityCompensationIssuanceV2");
+      // The public type is the AnyObject/AnyTransaction member and claims the
+      // object_type, exactly like any ordinary concrete object.
+      expect(unionMembersOf(source, "AnyTransaction")).toContain(
+        "OCFEquityCompensationIssuance"
+      );
+      const map = source.slice(
+        source.indexOf("export interface ObjectTypeMap {")
+      );
+      expect(map).toContain(
+        "TX_EQUITY_COMPENSATION_ISSUANCE: OCFEquityCompensationIssuance;"
+      );
+    });
+
+    it("experimental=unstable: collapses the public $id to the latest alpha/beta shape", () => {
+      // v2 is alpha; under `unstable` it becomes the public shape. Give the two
+      // shapes distinguishable fields so we can tell which one was selected.
+      const v1 = {
+        ...versionShape(1, "stable"),
+        properties: {
+          object_type: { const: "TX_EQUITY_COMPENSATION_ISSUANCE" },
+          legacy_field: { $ref: TYPE_NUMERIC.$id },
+          id: {},
+        },
+        required: ["legacy_field"],
+      };
+      const v2 = {
+        ...versionShape(2, "alpha"),
+        properties: {
+          object_type: { const: "TX_EQUITY_COMPENSATION_ISSUANCE" },
+          new_field: { $ref: TYPE_NUMERIC.$id },
+          id: {},
+        },
+        required: ["new_field"],
+      };
+      const { source } = generateTypeScript(
+        [
+          ...baseInputs,
+          dispatcher({ ["x-ocf-version-dispatcher"]: true }),
+          v1,
+          v2,
+        ],
+        { experimental: "unstable" }
+      );
+      const iface = source.slice(
+        source.indexOf("export interface OCFEquityCompensationIssuance {")
+      );
+      expect(iface).toContain("new_field");
+      expect(source).not.toContain("legacy_field");
+    });
   });
 });

--- a/utils/schema-utils/TypeScriptGenerator.ts
+++ b/utils/schema-utils/TypeScriptGenerator.ts
@@ -33,9 +33,11 @@
  */
 
 import {
+  applyExperimentalMode,
   buildSchemaRegistry,
   composeAll,
   ComposedSchemaJson,
+  ExperimentalMode,
   isBackwardsCompatibleWrapper,
   RawSchemaJson,
   versionShapeOwnerMap,
@@ -59,6 +61,12 @@ export type GenerateTypeScriptOptions = {
    *  flattened into every concrete type via composition, so nothing references
    *  them — emitting them only adds orphaned, easily-misused base shapes. */
   includePrimitives?: boolean;
+  /** How to resolve version dispatchers (see `ExperimentalMode`). Defaults to
+   *  `"compatibility"` — the dispatcher stays a `V1 | V2 | …` union — so output
+   *  is unchanged from before the flag existed. With `"none"` / `"unstable"`
+   *  each dispatcher collapses to a single selected versioned shape and its
+   *  other shapes are not emitted. */
+  experimental?: ExperimentalMode;
 };
 
 const DEFAULT_PREFIX = "OCF";
@@ -544,7 +552,7 @@ export type GenerateTypeScriptResult = {
  * for every schema in `rawSchemas`.
  */
 export function generateTypeScript(
-  rawSchemas: RawSchemaJson[],
+  inputSchemas: RawSchemaJson[],
   options: GenerateTypeScriptOptions = {}
 ): GenerateTypeScriptResult {
   const {
@@ -553,7 +561,15 @@ export function generateTypeScript(
     banner,
     onMissingRef = "unknown",
     includePrimitives = false,
+    experimental = "compatibility",
   } = options;
+
+  // Resolve version dispatchers per the experimental policy. Under `none` /
+  // `unstable` this collapses each dispatcher to a single selected versioned
+  // shape (and drops the others) BEFORE composition, so the rest of codegen
+  // sees only ordinary schemas. `compatibility` leaves the dispatchers intact
+  // for the union/aggregate handling below.
+  const rawSchemas = applyExperimentalMode(inputSchemas, experimental);
 
   // Compose so each object's inherited properties are flattened in; keep refs
   // (we map them to named types rather than inlining). Missing inheritance refs


### PR DESCRIPTION
## What

Adds an `--experimental` flag to the three tools that consume the OCF schema — `schema:compose`, `schema:gen-types`, and `docs:generate` — to choose how a [VersionWrapper dispatcher](docs/explainers/DesignPatterns.md) (`#584`) is resolved. All three accept the same flag and resolve dispatchers identically, so the composed schemas, generated types, and docs always agree.

| `--experimental` | Behavior for a dispatcher |
| --- | --- |
| `compatibility` **(default)** | Keep the dispatcher intact: the public `$id` is the **union** of every listed shape (codegen emits `V1 \| V2 \| …`; docs fold all versions into one page). Unchanged from prior behavior. |
| `none` | Drop the dispatcher; expose only the **latest `x-ocf-stability=stable`** shape under the public `$id`. Pre-release / older shapes leave the public surface. (No stable shape → latest overall + warning.) |
| `unstable` | Expose the **latest `alpha`/`beta`** shape, falling back to the latest `stable` when none is pre-release. |

## How

A single shared pre-pass, `applyExperimentalMode(rawSchemas, mode)`, in `SchemaComposer`:

- `compatibility` → no-op pass-through; the existing dispatcher-aware code paths handle the union / folded page.
- `none` / `unstable` → collapse each dispatcher to its selected versioned shape (re-homed onto the dispatcher's stable public `$id`) and remove the other version shapes entirely. After this pass there are **no dispatchers left**, so the composer, codegen, doc generator, and dereferencer all operate on ordinary schemas with zero per-tool dispatcher special-casing.

"Latest" is the highest `.v#` number among the candidate shapes. A property that references a dispatcher's public `$id` keeps working — that `$id` now resolves to the collapsed shape.

Also: stop writing vacuous `"properties": {}` / `"required": []` to composed/dereferenced **enum and scalar** output files (`omitEmptyComposedContainers`).

## Testing

- 175 unit tests pass (23 suites), prettier clean. New coverage for version selection, `applyExperimentalMode` collapse/drop, TS-gen `none`/`unstable`, doc-gen collapse, and the output cleanup.
- Exercised end-to-end on a real dispatcher fixture through the **compose** CLI (all 3 modes incl. `--dereference`: correct collapse, version files dropped, public `$id` preserved) and the **docs** generator (`compatibility` = folded page with v1+v2 + STABLE/ALPHA badges; `none` = plain page with the stable shape; `unstable` = plain page with the alpha shape).

## Notes

- Default is `compatibility`, so existing output is unchanged until a consumer opts into `none` / `unstable`.
- Branches off `main` (which now includes #584). The diff is exactly the `--experimental` feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)